### PR TITLE
建立 .NET 8 後端初始骨架

### DIFF
--- a/DentstageToolApp_Backend.sln
+++ b/DentstageToolApp_Backend.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DentstageToolApp.Api", "src/DentstageToolApp.Api/DentstageToolApp.Api.csproj", "{DB66C368-844C-4943-A325-BA0881FC4E0C}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {DB66C368-844C-4943-A325-BA0881FC4E0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {DB66C368-844C-4943-A325-BA0881FC4E0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {DB66C368-844C-4943-A325-BA0881FC4E0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {DB66C368-844C-4943-A325-BA0881FC4E0C}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# DentstageToolApp_Backend
+# DentstageToolApp 後端專案
+
+本儲存庫提供「卓越凹痕工廠 APP」後端服務的基礎架構。本次提交完成 .NET 8 Web API 專案骨架，未來可逐步擴充各式業務模組。
+
+## 專案結構
+
+```
+DentstageToolApp_Backend/
+├─ DentstageToolApp_Backend.sln        # 方案檔，統一管理所有後端模組
+├─ global.json                          # 指定 .NET SDK 版本，確保環境一致
+├─ src/
+│  └─ DentstageToolApp.Api/             # Web API 專案目錄
+│     ├─ Controllers/
+│     │  └─ HealthCheckController.cs    # 健康檢查 API，提供服務狀態
+│     ├─ Program.cs                     # 服務啟動與中介層設定
+│     ├─ appsettings*.json              # 組態檔，可依環境調整
+│     └─ Properties/launchSettings.json # 開發階段啟動設定
+├─ db_docs/                             # 既有資料庫文件
+└─ 卓越-凹痕工廠APP重製-頁面規劃-API表 - 後台.csv
+```
+
+## 開發環境建議
+
+1. 安裝 [.NET SDK 8.0](https://dotnet.microsoft.com/download/dotnet/8.0)。
+2. 於專案根目錄執行 `dotnet restore` 下載所需套件。
+3. 以 `dotnet run --project src/DentstageToolApp.Api` 啟動後端服務。
+4. 服務啟動後，可透過 `https://localhost:7249/swagger` 瀏覽 API 說明文件。
+
+> 若在本地環境使用 Visual Studio 或 Rider，請直接開啟 `DentstageToolApp_Backend.sln` 方案檔。
+
+## 後續開發提醒
+
+- 所有程式碼請維持中文註解，清楚說明邏輯與目的。
+- 新增模組時，建議以資料夾劃分領域 (例如 `Modules/Orders`)，方便維護。
+- 若需串接資料庫，請優先建立資料夾 `Infrastructure/` 並撰寫對應的 Repository 或 DbContext。
+
+歡迎依據專案需求持續擴充功能與測試。若需更多背景資訊，請參考 `db_docs/` 與原始 API 規格文件。

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMajor"
+  }
+}

--- a/src/DentstageToolApp.Api/Controllers/HealthCheckController.cs
+++ b/src/DentstageToolApp.Api/Controllers/HealthCheckController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace DentstageToolApp.Api.Controllers;
+
+/// <summary>
+/// 健康檢查控制器，用於確認服務是否正常運作。
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class HealthCheckController : ControllerBase
+{
+    /// <summary>
+    /// 回傳系統狀態與時間戳記，方便監控與排錯。
+    /// </summary>
+    /// <returns>含狀態、訊息與時間的健康檢查資訊。</returns>
+    [HttpGet]
+    public IActionResult Get()
+    {
+        // 使用匿名物件整理健康檢查資訊，後續可擴充更多系統資料
+        var response = new
+        {
+            status = "healthy",
+            message = "後端服務啟動成功",
+            timestamp = DateTimeOffset.UtcNow
+        };
+
+        return Ok(response);
+    }
+}

--- a/src/DentstageToolApp.Api/DentstageToolApp.Api.csproj
+++ b/src/DentstageToolApp.Api/DentstageToolApp.Api.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>DentstageToolApp.Api</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/src/DentstageToolApp.Api/Program.cs
+++ b/src/DentstageToolApp.Api/Program.cs
@@ -1,0 +1,30 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// ---------- 服務註冊區 ----------
+// 註冊控制器，提供 API 與路由的基礎功能
+builder.Services.AddControllers();
+// 啟用 Swagger 方便初期開發與溝通 API 規格
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// ---------- 中介層設定區 ----------
+// 在開發階段顯示 Swagger UI，方便快速驗證 API
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+// 啟用 HTTPS 重新導向，確保外部存取使用安全通道
+app.UseHttpsRedirection();
+
+// 啟用授權流程，後續可延伸加入身份驗證
+app.UseAuthorization();
+
+// 將控制器路由對應到實際的端點
+app.MapControllers();
+
+// 啟動 Web 應用程式
+app.Run();

--- a/src/DentstageToolApp.Api/Properties/launchSettings.json
+++ b/src/DentstageToolApp.Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "DentstageToolApp.Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7249;http://localhost:5249",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/DentstageToolApp.Api/appsettings.Development.json
+++ b/src/DentstageToolApp.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/DentstageToolApp.Api/appsettings.json
+++ b/src/DentstageToolApp.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## 摘要
- 建立 DentstageToolApp_Backend 解決方案與 global.json，統一專案 SDK 版本
- 建立 DentstageToolApp.Api Web API 專案並新增健康檢查端點作為初始範本
- 補充 README 說明專案結構與啟動方式，提供後續開發指引

## 測試
- 未執行（環境缺少 .NET SDK）

------
https://chatgpt.com/codex/tasks/task_e_68d610b491588324a89abdebfc673f72