### PR TITLE
調整啟動設定以支援 MySQL 與 Swagger 組態

### DIFF
--- a/src/DentstageToolApp.Api/appsettings.Development.json
+++ b/src/DentstageToolApp.Api/appsettings.Development.json
@@ -6,6 +6,9 @@
     }
   },
   "ConnectionStrings": {
-    "DentstageToolAppDatabase": "Server=localhost;Database=DentstageToolApp_Dev;Trusted_Connection=True;TrustServerCertificate=True;"
+    "DentstageToolAppDatabase": "Server=localhost;Port=3306;Database=dentstage_tool_app_dev;User=root;Password=ChangeMe123!;CharSet=utf8mb4;SslMode=None;"
+  },
+  "Swagger": {
+    "Enabled": true
   }
 }

--- a/src/DentstageToolApp.Api/appsettings.json
+++ b/src/DentstageToolApp.Api/appsettings.json
@@ -6,7 +6,13 @@
     }
   },
   "ConnectionStrings": {
-    "DentstageToolAppDatabase": "Server=localhost;Database=DentstageToolApp;Trusted_Connection=True;TrustServerCertificate=True;"
+    "DentstageToolAppDatabase": "Server=localhost;Port=3306;Database=dentstage_tool_app;User=root;Password=ChangeMe123!;CharSet=utf8mb4;SslMode=None;"
+  },
+  "Swagger": {
+    "Enabled": false,
+    "RoutePrefix": "swagger",
+    "EndpointName": "Dentstage Tool App API v1",
+    "DocumentTitle": "Dentstage Tool App 後端 API 文件"
   },
   "AllowedHosts": "*"
 }

--- a/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
+++ b/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 namespace DentstageToolApp.Infrastructure.Data;
 
 /// <summary>
-/// 系統資料庫內容類別，透過 DB First 設定對應資料表結構。
+/// 系統資料庫內容類別，對應 MySQL 資料表結構與欄位限制。
 /// </summary>
 public class DentstageToolAppContext : DbContext
 {
@@ -146,7 +146,9 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.UserUid).HasMaxLength(100);
         entity.Property(e => e.UserName).HasMaxLength(100);
         entity.Property(e => e.Status).HasMaxLength(20);
-        entity.Property(e => e.FixType).HasMaxLength(50);
+        entity.Property(e => e.FixType)
+            .HasMaxLength(50)
+            .HasColumnName("Fix_Type");
         entity.Property(e => e.CarUid)
             .HasMaxLength(100)
             .HasColumnName("CarUID");
@@ -201,6 +203,7 @@ public class DentstageToolAppContext : DbContext
             .HasMaxLength(255)
             .HasColumnName("Discount_reason");
         entity.Property(e => e.BookDate)
+            .HasMaxLength(20)
             .HasColumnName("Book_Date");
         entity.Property(e => e.BookMethod)
             .HasMaxLength(50)
@@ -252,6 +255,8 @@ public class DentstageToolAppContext : DbContext
             .HasColumnName("CurrentStatus_User");
         entity.Property(e => e.FixExpect)
             .HasMaxLength(50);
+        entity.Property(e => e.Reject)
+            .HasColumnType("tinyint(1)");
         entity.Property(e => e.RejectReason)
             .HasMaxLength(255)
             .HasColumnName("Reject_reason");
@@ -269,6 +274,7 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.FixExpectHour)
             .HasColumnName("FixExpect_Hour");
         entity.Property(e => e.FlagRegularCustomer)
+            .HasColumnType("tinyint(1)")
             .HasColumnName("Flag_RegularCustomer");
 
         entity.HasOne(d => d.Customer)
@@ -347,16 +353,20 @@ public class DentstageToolAppContext : DbContext
             .HasMaxLength(100)
             .HasColumnName("QuatationUID");
         entity.Property(e => e.BookDate)
+            .HasMaxLength(20)
             .HasColumnName("Book_Date");
         entity.Property(e => e.BookMethod)
             .HasMaxLength(50)
             .HasColumnName("Book_method");
         entity.Property(e => e.WorkDate)
+            .HasMaxLength(20)
             .HasColumnName("Work_Date");
         entity.Property(e => e.WorkDateRemark)
             .HasMaxLength(255)
             .HasColumnName("Work_Date_remark");
-        entity.Property(e => e.FixType).HasMaxLength(50);
+        entity.Property(e => e.FixType)
+            .HasMaxLength(50)
+            .HasColumnName("Fix_Type");
         entity.Property(e => e.Content).HasColumnType("text");
         entity.Property(e => e.CarReserved).HasMaxLength(50);
         entity.Property(e => e.Remark).HasColumnType("text");
@@ -408,8 +418,10 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.Rebate)
             .HasColumnType("decimal(10,2)");
         entity.Property(e => e.FlagRegularCustomer)
+            .HasColumnType("tinyint(1)")
             .HasColumnName("Flag_RegularCustomer");
         entity.Property(e => e.FlagExternalCooperation)
+            .HasColumnType("tinyint(1)")
             .HasColumnName("Flag_ExternalCooperation");
 
         entity.HasOne(d => d.Quatation)
@@ -542,6 +554,7 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.Cost)
             .HasColumnType("decimal(10,2)");
         entity.Property(e => e.FlagFinish)
+            .HasColumnType("tinyint(1)")
             .HasColumnName("Flag_Finish");
         entity.Property(e => e.FinishCost)
             .HasColumnType("decimal(10,2)")
@@ -567,6 +580,12 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.StoreUid).HasMaxLength(100);
         entity.Property(e => e.UserUid).HasMaxLength(100);
         entity.Property(e => e.Status).HasMaxLength(50);
+        entity.Property(e => e.CancelDate)
+            .HasMaxLength(20);
+        entity.Property(e => e.BookDate)
+            .HasMaxLength(20);
+        entity.Property(e => e.FixDate)
+            .HasMaxLength(20);
         entity.Property(e => e.CustomerUid)
             .HasMaxLength(100)
             .HasColumnName("CustomerUID");
@@ -578,6 +597,7 @@ public class DentstageToolAppContext : DbContext
             .HasMaxLength(20)
             .HasColumnName("CustomerPhone_filter");
         entity.Property(e => e.FlagBlack)
+            .HasColumnType("tinyint(1)")
             .HasColumnName("Flag_Black");
         entity.Property(e => e.Reason)
             .HasMaxLength(255);

--- a/src/DentstageToolApp.Infrastructure/DentstageToolApp.Infrastructure.csproj
+++ b/src/DentstageToolApp.Infrastructure/DentstageToolApp.Infrastructure.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
   </ItemGroup>
 </Project>

--- a/src/DentstageToolApp.Infrastructure/Entities/BlackList.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/BlackList.cs
@@ -48,19 +48,19 @@ public class BlackList
     public string? Status { get; set; }
 
     /// <summary>
-    /// 取消日期。
+    /// 取消日期（以字串儲存，沿用舊系統格式）。
     /// </summary>
-    public DateOnly? CancelDate { get; set; }
+    public string? CancelDate { get; set; }
 
     /// <summary>
-    /// 預約日期。
+    /// 預約日期（以字串儲存，沿用舊系統格式）。
     /// </summary>
-    public DateOnly? BookDate { get; set; }
+    public string? BookDate { get; set; }
 
     /// <summary>
-    /// 修復日期。
+    /// 修復日期（以字串儲存，沿用舊系統格式）。
     /// </summary>
-    public DateOnly? FixDate { get; set; }
+    public string? FixDate { get; set; }
 
     /// <summary>
     /// 顧客識別碼。

--- a/src/DentstageToolApp.Infrastructure/Entities/Order.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/Order.cs
@@ -188,9 +188,9 @@ public class Order
     public string? QuatationUid { get; set; }
 
     /// <summary>
-    /// 預約日期。
+    /// 預約日期（以字串儲存，方便對應 MySQL VARCHAR 欄位）。
     /// </summary>
-    public DateOnly? BookDate { get; set; }
+    public string? BookDate { get; set; }
 
     /// <summary>
     /// 預約方式。
@@ -198,9 +198,9 @@ public class Order
     public string? BookMethod { get; set; }
 
     /// <summary>
-    /// 預計施工日期。
+    /// 預計施工日期（以字串儲存，保留原始填寫格式）。
     /// </summary>
-    public DateOnly? WorkDate { get; set; }
+    public string? WorkDate { get; set; }
 
     /// <summary>
     /// 施工日期備註。


### PR DESCRIPTION
## 摘要
- 調整 Program.cs 套用可配置的 Swagger 參數並導入 MySQL 連線與重試策略
- 更新環境設定改用 MySQL 連線字串並新增 Swagger 顯示開關
- 依據 db_docs 修正資料模型欄位型別與 Pomelo MySQL 相依套件

## 測試
- 未執行（環境未安裝 dotnet CLI）

------
https://chatgpt.com/codex/tasks/task_e_68db4a76dbc883249e65fe5b92227e68