### PR TITLE
新增登入授權與裝置驗證流程

### DIFF
--- a/db_docs/DeviceRegistrations.txt
+++ b/db_docs/DeviceRegistrations.txt
@@ -1,0 +1,20 @@
+CREATE TABLE DeviceRegistrations (
+    CreationTimestamp      DATETIME,
+    CreatedBy              VARCHAR(50),
+    ModificationTimestamp  DATETIME,
+    ModifiedBy             VARCHAR(50),
+    DeviceRegistrationUID  VARCHAR(100) PRIMARY KEY,
+    UserUID                VARCHAR(100) NOT NULL,
+    DeviceKey              VARCHAR(150) NOT NULL,
+    DeviceName             VARCHAR(100),
+    Status                 VARCHAR(20)  NOT NULL,
+    IsBlackListed          TINYINT(1)   NOT NULL DEFAULT 0,
+    LastSignInAt           DATETIME,
+    ExpireAt               DATETIME,
+    CONSTRAINT FK_DeviceRegistrations_UserAccounts FOREIGN KEY (UserUID)
+        REFERENCES UserAccounts (UserUID)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IX_DeviceRegistrations_UserUID_DeviceKey
+    ON DeviceRegistrations (UserUID, DeviceKey);

--- a/db_docs/RefreshTokens.txt
+++ b/db_docs/RefreshTokens.txt
@@ -1,0 +1,23 @@
+CREATE TABLE RefreshTokens (
+    CreationTimestamp      DATETIME,
+    CreatedBy              VARCHAR(50),
+    ModificationTimestamp  DATETIME,
+    ModifiedBy             VARCHAR(50),
+    RefreshTokenUID        VARCHAR(100) PRIMARY KEY,
+    Token                  VARCHAR(500) NOT NULL,
+    UserUID                VARCHAR(100) NOT NULL,
+    DeviceRegistrationUID  VARCHAR(100),
+    ExpireAt               DATETIME      NOT NULL,
+    LastUsedAt             DATETIME,
+    IsRevoked              TINYINT(1)    NOT NULL DEFAULT 0,
+    RevokedAt              DATETIME,
+    CONSTRAINT FK_RefreshTokens_UserAccounts FOREIGN KEY (UserUID)
+        REFERENCES UserAccounts (UserUID)
+        ON DELETE CASCADE,
+    CONSTRAINT FK_RefreshTokens_DeviceRegistrations FOREIGN KEY (DeviceRegistrationUID)
+        REFERENCES DeviceRegistrations (DeviceRegistrationUID)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IX_RefreshTokens_Token
+    ON RefreshTokens (Token);

--- a/db_docs/UserAccounts.txt
+++ b/db_docs/UserAccounts.txt
@@ -1,0 +1,11 @@
+CREATE TABLE UserAccounts (
+    CreationTimestamp     DATETIME,
+    CreatedBy             VARCHAR(50),
+    ModificationTimestamp DATETIME,
+    ModifiedBy            VARCHAR(50),
+    UserUID               VARCHAR(100) PRIMARY KEY,
+    DisplayName           VARCHAR(100),
+    Role                  VARCHAR(50),
+    IsActive              TINYINT(1) NOT NULL DEFAULT 1,
+    LastLoginAt           DATETIME
+);

--- a/src/DentstageToolApp.Api/Admin/CreateUserDeviceRequest.cs
+++ b/src/DentstageToolApp.Api/Admin/CreateUserDeviceRequest.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Admin;
+
+/// <summary>
+/// 管理者建立使用者與裝置時所需的請求資料，僅保留必要欄位。
+/// </summary>
+public class CreateUserDeviceRequest
+{
+    /// <summary>
+    /// 使用者顯示名稱，提供前台或權杖載明使用者身分。
+    /// </summary>
+    [Required(ErrorMessage = "請輸入使用者顯示名稱。")]
+    [MaxLength(100, ErrorMessage = "顯示名稱長度不可超過 100 字元。")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 使用者角色，預設給予一般使用者權限。
+    /// </summary>
+    [MaxLength(50, ErrorMessage = "角色長度不可超過 50 字元。")]
+    public string? Role { get; set; }
+
+    /// <summary>
+    /// 裝置專屬機碼，登入時會以此進行驗證。
+    /// </summary>
+    [Required(ErrorMessage = "請提供裝置機碼。")]
+    [MaxLength(150, ErrorMessage = "裝置機碼長度不可超過 150 字元。")]
+    public string DeviceKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 裝置名稱或註記，協助管理者辨識來源。
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "裝置名稱長度不可超過 100 字元。")]
+    public string? DeviceName { get; set; }
+
+    /// <summary>
+    /// 建立者名稱，便於稽核追蹤，未填寫時預設為 AdminAPI。
+    /// </summary>
+    [MaxLength(50, ErrorMessage = "建立者名稱長度不可超過 50 字元。")]
+    public string? OperatorName { get; set; }
+}

--- a/src/DentstageToolApp.Api/Admin/CreateUserDeviceResponse.cs
+++ b/src/DentstageToolApp.Api/Admin/CreateUserDeviceResponse.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace DentstageToolApp.Api.Admin;
+
+/// <summary>
+/// 管理者建立帳號與裝置後的回應資料，回傳關鍵識別資訊。
+/// </summary>
+public class CreateUserDeviceResponse
+{
+    /// <summary>
+    /// 新建立的使用者識別碼。
+    /// </summary>
+    public string UserUid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 使用者顯示名稱。
+    /// </summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// 使用者角色資訊。
+    /// </summary>
+    public string? Role { get; set; }
+
+    /// <summary>
+    /// 新增裝置註冊的唯一識別碼。
+    /// </summary>
+    public string DeviceRegistrationUid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 裝置專屬機碼。
+    /// </summary>
+    public string DeviceKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 裝置名稱或註記。
+    /// </summary>
+    public string? DeviceName { get; set; }
+
+    /// <summary>
+    /// 裝置目前狀態，預期為 Active。
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 裝置過期時間，尚未設定時為 null。
+    /// </summary>
+    public DateTime? ExpireAt { get; set; }
+
+    /// <summary>
+    /// 給前端或管理者的提示訊息。
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/DentstageToolApp.Api/Auth/LoginRequest.cs
+++ b/src/DentstageToolApp.Api/Auth/LoginRequest.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Auth;
+
+/// <summary>
+/// 登入請求資料傳輸物件，負責攜帶帳號密碼與裝置信息。
+/// </summary>
+public class LoginRequest
+{
+    /// <summary>
+    /// 登入帳號。
+    /// </summary>
+    [Required(ErrorMessage = "帳號為必填欄位。")]
+    [MaxLength(100, ErrorMessage = "帳號長度不可超過 100 字元。")]
+    public string Account { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 登入密碼（明碼，服務端會負責雜湊比對）。
+    /// </summary>
+    [Required(ErrorMessage = "密碼為必填欄位。")]
+    [MaxLength(100, ErrorMessage = "密碼長度不可超過 100 字元。")]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 裝置機碼，供後端綁定裝置使用。
+    /// </summary>
+    [Required(ErrorMessage = "請提供裝置機碼。")]
+    [MaxLength(150, ErrorMessage = "裝置機碼長度不可超過 150 字元。")]
+    public string DeviceKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 裝置顯示名稱，方便後台辨識來源。
+    /// </summary>
+    [MaxLength(100, ErrorMessage = "裝置名稱長度不可超過 100 字元。")]
+    public string? DeviceName { get; set; }
+}

--- a/src/DentstageToolApp.Api/Auth/LoginRequest.cs
+++ b/src/DentstageToolApp.Api/Auth/LoginRequest.cs
@@ -3,34 +3,14 @@ using System.ComponentModel.DataAnnotations;
 namespace DentstageToolApp.Api.Auth;
 
 /// <summary>
-/// 登入請求資料傳輸物件，負責攜帶帳號密碼與裝置信息。
+/// 登入請求資料傳輸物件，目前僅需攜帶裝置機碼供後端驗證。
 /// </summary>
 public class LoginRequest
 {
     /// <summary>
-    /// 登入帳號。
-    /// </summary>
-    [Required(ErrorMessage = "帳號為必填欄位。")]
-    [MaxLength(100, ErrorMessage = "帳號長度不可超過 100 字元。")]
-    public string Account { get; set; } = string.Empty;
-
-    /// <summary>
-    /// 登入密碼（明碼，服務端會負責雜湊比對）。
-    /// </summary>
-    [Required(ErrorMessage = "密碼為必填欄位。")]
-    [MaxLength(100, ErrorMessage = "密碼長度不可超過 100 字元。")]
-    public string Password { get; set; } = string.Empty;
-
-    /// <summary>
-    /// 裝置機碼，供後端綁定裝置使用。
+    /// 裝置機碼，供後端辨識與綁定裝置使用。
     /// </summary>
     [Required(ErrorMessage = "請提供裝置機碼。")]
     [MaxLength(150, ErrorMessage = "裝置機碼長度不可超過 150 字元。")]
     public string DeviceKey { get; set; } = string.Empty;
-
-    /// <summary>
-    /// 裝置顯示名稱，方便後台辨識來源。
-    /// </summary>
-    [MaxLength(100, ErrorMessage = "裝置名稱長度不可超過 100 字元。")]
-    public string? DeviceName { get; set; }
 }

--- a/src/DentstageToolApp.Api/Auth/LoginResponse.cs
+++ b/src/DentstageToolApp.Api/Auth/LoginResponse.cs
@@ -1,0 +1,47 @@
+namespace DentstageToolApp.Api.Auth;
+
+/// <summary>
+/// 登入回應資料傳輸物件，提供 Token 與使用者資訊。
+/// </summary>
+public class LoginResponse
+{
+    /// <summary>
+    /// 存取權杖內容。
+    /// </summary>
+    public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 存取權杖到期時間（UTC）。
+    /// </summary>
+    public DateTime AccessTokenExpireAt { get; set; }
+
+    /// <summary>
+    /// Refresh Token 字串。
+    /// </summary>
+    public string RefreshToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Refresh Token 過期時間（UTC）。
+    /// </summary>
+    public DateTime RefreshTokenExpireAt { get; set; }
+
+    /// <summary>
+    /// 使用者顯示名稱。
+    /// </summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// 使用者角色資訊。
+    /// </summary>
+    public string? Role { get; set; }
+
+    /// <summary>
+    /// 對裝置狀態的說明，例如 Active 或 Disabled。
+    /// </summary>
+    public string DeviceStatus { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 服務端提示訊息，可供前端顯示或除錯。
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/DentstageToolApp.Api/Auth/RefreshTokenRequest.cs
+++ b/src/DentstageToolApp.Api/Auth/RefreshTokenRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Auth;
+
+/// <summary>
+/// 使用 Refresh Token 重新取得 Access Token 的請求物件。
+/// </summary>
+public class RefreshTokenRequest
+{
+    /// <summary>
+    /// 舊的 Refresh Token。
+    /// </summary>
+    [Required(ErrorMessage = "請提供 Refresh Token。")]
+    public string RefreshToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 再次驗證裝置機碼，確保 Token 與裝置綁定。
+    /// </summary>
+    [Required(ErrorMessage = "請提供裝置機碼。")]
+    [MaxLength(150, ErrorMessage = "裝置機碼長度不可超過 150 字元。")]
+    public string DeviceKey { get; set; } = string.Empty;
+}

--- a/src/DentstageToolApp.Api/BackgroundJobs/RefreshTokenCleanupService.cs
+++ b/src/DentstageToolApp.Api/BackgroundJobs/RefreshTokenCleanupService.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using DentstageToolApp.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.BackgroundJobs;
+
+/// <summary>
+/// 週期性清理過期 Refresh Token 的背景服務，維持資料庫整潔。
+/// </summary>
+public class RefreshTokenCleanupService : BackgroundService
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<RefreshTokenCleanupService> _logger;
+    private readonly TimeSpan _cleanupInterval = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// 建構子，注入必要的相依物件。
+    /// </summary>
+    public RefreshTokenCleanupService(
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<RefreshTokenCleanupService> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // 服務啟動時先進行一次清理，避免長期累積
+        await CleanupAsync(stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_cleanupInterval, stoppingToken);
+                await CleanupAsync(stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                // 取消時直接跳出迴圈，避免噴出不必要的錯誤
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 實際執行清理的流程。
+    /// </summary>
+    private async Task CleanupAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<DentstageToolAppContext>();
+        var now = DateTime.UtcNow;
+
+        // ---------- 資料查詢區 ----------
+        // 找出所有過期或已撤銷超過七天的 Token
+        var expiredTokens = await context.RefreshTokens
+            .Where(x => x.ExpireAt < now || (x.IsRevoked && x.RevokedAt != null && x.RevokedAt < now.AddDays(-7)))
+            .ToListAsync(cancellationToken);
+
+        if (expiredTokens.Count == 0)
+        {
+            _logger.LogDebug("Refresh Token 清理結果：無過期資料。");
+            return;
+        }
+
+        // ---------- 方法區 ----------
+        // 批次移除過期資料，減少資料庫負擔
+        context.RefreshTokens.RemoveRange(expiredTokens);
+        await context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Refresh Token 清理完成，共移除 {Count} 筆資料。", expiredTokens.Count);
+    }
+}

--- a/src/DentstageToolApp.Api/Controllers/AdminAccountsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/AdminAccountsController.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Admin;
+using DentstageToolApp.Api.Services.Admin;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Controllers;
+
+/// <summary>
+/// 管理者帳號維運 API，提供建立帳號與裝置的功能。
+/// </summary>
+[ApiController]
+[Route("api/admin/accounts")]
+public class AdminAccountsController : ControllerBase
+{
+    private readonly IAccountAdminService _accountAdminService;
+    private readonly ILogger<AdminAccountsController> _logger;
+
+    /// <summary>
+    /// 建構子，注入管理者帳號服務與記錄器。
+    /// </summary>
+    public AdminAccountsController(IAccountAdminService accountAdminService, ILogger<AdminAccountsController> logger)
+    {
+        _accountAdminService = accountAdminService;
+        _logger = logger;
+    }
+
+    // ---------- API 呼叫區 ----------
+
+    /// <summary>
+    /// 建立新的使用者帳號與對應裝置機碼。
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(CreateUserDeviceResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<CreateUserDeviceResponse>> CreateAccountWithDevice([FromBody] CreateUserDeviceRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            // 回傳 400 並附帶詳細驗證錯誤
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var response = await _accountAdminService.CreateUserWithDeviceAsync(request, cancellationToken);
+            return StatusCode(StatusCodes.Status201Created, response);
+        }
+        catch (AccountAdminException ex)
+        {
+            _logger.LogWarning(ex, "建立帳號失敗：{Message}", ex.Message);
+            return BuildErrorResponse(ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "建立帳號流程發生未預期錯誤。");
+            return BuildErrorResponse(HttpStatusCode.InternalServerError, "系統處理請求時發生錯誤，請稍後再試。");
+        }
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 統一建立 ProblemDetails 物件，確保錯誤輸出一致。
+    /// </summary>
+    private ActionResult BuildErrorResponse(HttpStatusCode statusCode, string message)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = (int)statusCode,
+            Title = "建立帳號失敗",
+            Detail = message,
+            Instance = HttpContext.Request.Path
+        };
+
+        return StatusCode(problem.Status.Value, problem);
+    }
+
+    // ---------- 生命週期 ----------
+    // 控制器目前無額外生命週期事件，保留區塊供未來擴充。
+}

--- a/src/DentstageToolApp.Api/Controllers/AuthController.cs
+++ b/src/DentstageToolApp.Api/Controllers/AuthController.cs
@@ -29,7 +29,7 @@ public class AuthController : ControllerBase
     // ---------- API 呼叫區 ----------
 
     /// <summary>
-    /// 使用帳號、密碼與裝置機碼進行登入，並回傳權杖。
+    /// 透過裝置機碼進行登入，若驗證成功則回傳權杖。
     /// </summary>
     [HttpPost("login")]
     [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]

--- a/src/DentstageToolApp.Api/Controllers/AuthController.cs
+++ b/src/DentstageToolApp.Api/Controllers/AuthController.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using DentstageToolApp.Api.Auth;
+using DentstageToolApp.Api.Services.Auth;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Controllers;
+
+/// <summary>
+/// 身份驗證相關 API 控制器，負責處理登入與 Token 更新流程。
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService _authService;
+    private readonly ILogger<AuthController> _logger;
+
+    /// <summary>
+    /// 建構子，注入身份驗證服務與記錄器。
+    /// </summary>
+    public AuthController(IAuthService authService, ILogger<AuthController> logger)
+    {
+        _authService = authService;
+        _logger = logger;
+    }
+
+    // ---------- API 呼叫區 ----------
+
+    /// <summary>
+    /// 使用帳號、密碼與裝置機碼進行登入，並回傳權杖。
+    /// </summary>
+    [HttpPost("login")]
+    [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            // 參數驗證失敗時，直接回傳 400 詳細錯誤
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var response = await _authService.LoginAsync(request, cancellationToken);
+            return Ok(response);
+        }
+        catch (AuthException ex)
+        {
+            _logger.LogWarning(ex, "登入失敗：{Message}", ex.Message);
+            return BuildAuthErrorResponse(ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "登入流程發生未預期錯誤。");
+            return BuildAuthErrorResponse(HttpStatusCode.InternalServerError, "系統處理登入時發生錯誤，請稍後再試。");
+        }
+    }
+
+    /// <summary>
+    /// 透過 Refresh Token 換取新的 Access Token。
+    /// </summary>
+    [HttpPost("token/refresh")]
+    [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<LoginResponse>> RefreshToken([FromBody] RefreshTokenRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var response = await _authService.RefreshTokenAsync(request, cancellationToken);
+            return Ok(response);
+        }
+        catch (AuthException ex)
+        {
+            _logger.LogWarning(ex, "Refresh Token 失敗：{Message}", ex.Message);
+            return BuildAuthErrorResponse(ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "更新 Token 時發生未預期錯誤。");
+            return BuildAuthErrorResponse(HttpStatusCode.InternalServerError, "系統處理 Token 更新時發生錯誤，請稍後再試。");
+        }
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 封裝錯誤回應格式，統一輸出 ProblemDetails。
+    /// </summary>
+    private ActionResult BuildAuthErrorResponse(HttpStatusCode statusCode, string message)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = (int)statusCode,
+            Title = "身份驗證失敗",
+            Detail = message,
+            Instance = HttpContext.Request.Path
+        };
+
+        return StatusCode(problem.Status.Value, problem);
+    }
+
+    // ---------- 生命週期 ----------
+    // 控制器沒有額外生命週期事件，保留此區塊供未來擴充使用。
+}

--- a/src/DentstageToolApp.Api/DentstageToolApp.Api.csproj
+++ b/src/DentstageToolApp.Api/DentstageToolApp.Api.csproj
@@ -14,5 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
   </ItemGroup>
 </Project>

--- a/src/DentstageToolApp.Api/Options/JwtOptions.cs
+++ b/src/DentstageToolApp.Api/Options/JwtOptions.cs
@@ -1,0 +1,32 @@
+namespace DentstageToolApp.Api.Options;
+
+/// <summary>
+/// JWT 設定值，從組態載入並提供服務使用。
+/// </summary>
+public class JwtOptions
+{
+    /// <summary>
+    /// Token 發行者。
+    /// </summary>
+    public string Issuer { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Token 受眾。
+    /// </summary>
+    public string Audience { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 簽章用密鑰字串。
+    /// </summary>
+    public string Secret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Access Token 有效分鐘數。
+    /// </summary>
+    public int AccessTokenMinutes { get; set; } = 30;
+
+    /// <summary>
+    /// Refresh Token 有效天數。
+    /// </summary>
+    public int RefreshTokenDays { get; set; } = 30;
+}

--- a/src/DentstageToolApp.Api/Program.cs
+++ b/src/DentstageToolApp.Api/Program.cs
@@ -4,6 +4,7 @@ using System.Text;
 using DentstageToolApp.Api.BackgroundJobs;
 using DentstageToolApp.Api.Options;
 using DentstageToolApp.Api.Services.Auth;
+using DentstageToolApp.Api.Services.Admin;
 using DentstageToolApp.Infrastructure.Data;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
@@ -98,6 +99,7 @@ builder.Services.AddAuthorization();
 
 // ---------- 自訂服務註冊 ----------
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IAccountAdminService, AccountAdminService>();
 builder.Services.AddHostedService<RefreshTokenCleanupService>();
 
 var app = builder.Build();

--- a/src/DentstageToolApp.Api/Services/Admin/AccountAdminException.cs
+++ b/src/DentstageToolApp.Api/Services/Admin/AccountAdminException.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Net;
+
+namespace DentstageToolApp.Api.Services.Admin;
+
+/// <summary>
+/// 管理者操作失敗時拋出的例外，攜帶對應的 HTTP 狀態碼。
+/// </summary>
+public class AccountAdminException : Exception
+{
+    /// <summary>
+    /// 對應的 HTTP 狀態碼，便於控制器轉換為 ProblemDetails。
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// 以訊息與狀態碼建立例外執行個體。
+    /// </summary>
+    public AccountAdminException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}

--- a/src/DentstageToolApp.Api/Services/Admin/AccountAdminService.cs
+++ b/src/DentstageToolApp.Api/Services/Admin/AccountAdminService.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Admin;
+using DentstageToolApp.Infrastructure.Data;
+using DentstageToolApp.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Services.Admin;
+
+/// <summary>
+/// 管理者帳號維運服務，負責建立使用者與裝置基礎資料。
+/// </summary>
+public class AccountAdminService : IAccountAdminService
+{
+    private readonly DentstageToolAppContext _context;
+    private readonly ILogger<AccountAdminService> _logger;
+
+    /// <summary>
+    /// 建構子，注入資料庫內容與記錄器。
+    /// </summary>
+    public AccountAdminService(DentstageToolAppContext context, ILogger<AccountAdminService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<CreateUserDeviceResponse> CreateUserWithDeviceAsync(CreateUserDeviceRequest request, CancellationToken cancellationToken)
+    {
+        var displayName = (request.DisplayName ?? string.Empty).Trim();
+        var deviceKey = (request.DeviceKey ?? string.Empty).Trim();
+        var role = string.IsNullOrWhiteSpace(request.Role) ? "User" : request.Role.Trim();
+        var deviceName = string.IsNullOrWhiteSpace(request.DeviceName) ? null : request.DeviceName.Trim();
+        var operatorName = string.IsNullOrWhiteSpace(request.OperatorName) ? "AdminAPI" : request.OperatorName.Trim();
+
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            // 透過服務內再次驗證，避免僅輸入空白字元
+            throw new AccountAdminException(HttpStatusCode.BadRequest, "顯示名稱不可為空白。");
+        }
+
+        if (string.IsNullOrWhiteSpace(deviceKey))
+        {
+            // 防止空白機碼寫入資料庫造成後續登入異常
+            throw new AccountAdminException(HttpStatusCode.BadRequest, "裝置機碼不可為空白。");
+        }
+
+        // 檢查裝置機碼是否已被使用，避免重複註冊造成登入衝突
+        var deviceExists = await _context.DeviceRegistrations
+            .AnyAsync(x => x.DeviceKey == deviceKey, cancellationToken);
+
+        if (deviceExists)
+        {
+            throw new AccountAdminException(HttpStatusCode.Conflict, "裝置機碼已存在，請改用其他機碼。");
+        }
+
+        var now = DateTime.UtcNow;
+        var userUid = Guid.NewGuid().ToString("N");
+        var deviceRegistrationUid = Guid.NewGuid().ToString("N");
+
+        var user = new UserAccount
+        {
+            UserUid = userUid,
+            DisplayName = displayName,
+            Role = role,
+            IsActive = true,
+            CreationTimestamp = now,
+            CreatedBy = operatorName,
+            ModificationTimestamp = now,
+            ModifiedBy = operatorName
+        };
+
+        var device = new DeviceRegistration
+        {
+            DeviceRegistrationUid = deviceRegistrationUid,
+            UserUid = userUid,
+            DeviceKey = deviceKey,
+            DeviceName = deviceName,
+            Status = "Active",
+            IsBlackListed = false,
+            CreationTimestamp = now,
+            CreatedBy = operatorName,
+            ModificationTimestamp = now,
+            ModifiedBy = operatorName,
+            ExpireAt = null,
+            UserAccount = user
+        };
+
+        // 透過導覽屬性綁定裝置與使用者，讓 EF Core 自動維護外鍵
+        user.DeviceRegistrations.Add(device);
+
+        await _context.UserAccounts.AddAsync(user, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("管理者 {Operator} 建立使用者 {UserUid} 與裝置 {DeviceUid}。", operatorName, userUid, deviceRegistrationUid);
+
+        return new CreateUserDeviceResponse
+        {
+            UserUid = userUid,
+            DisplayName = user.DisplayName,
+            Role = user.Role,
+            DeviceRegistrationUid = deviceRegistrationUid,
+            DeviceKey = device.DeviceKey,
+            DeviceName = device.DeviceName,
+            Status = device.Status,
+            ExpireAt = device.ExpireAt,
+            Message = "已建立帳號與裝置機碼。"
+        };
+    }
+}

--- a/src/DentstageToolApp.Api/Services/Admin/IAccountAdminService.cs
+++ b/src/DentstageToolApp.Api/Services/Admin/IAccountAdminService.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Admin;
+
+namespace DentstageToolApp.Api.Services.Admin;
+
+/// <summary>
+/// 定義管理者帳號維運所需的服務介面。
+/// </summary>
+public interface IAccountAdminService
+{
+    /// <summary>
+    /// 建立新的使用者與對應裝置機碼。
+    /// </summary>
+    Task<CreateUserDeviceResponse> CreateUserWithDeviceAsync(CreateUserDeviceRequest request, CancellationToken cancellationToken);
+}

--- a/src/DentstageToolApp.Api/Services/Auth/AuthException.cs
+++ b/src/DentstageToolApp.Api/Services/Auth/AuthException.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Net;
+
+namespace DentstageToolApp.Api.Services.Auth;
+
+/// <summary>
+/// 自訂身份驗證例外狀況，攜帶對應的 HTTP 狀態碼。
+/// </summary>
+public class AuthException : Exception
+{
+    /// <summary>
+    /// 建立例外狀況並指定狀態碼與訊息。
+    /// </summary>
+    public AuthException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>
+    /// 對應的 HTTP 狀態碼。
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+}

--- a/src/DentstageToolApp.Api/Services/Auth/AuthService.cs
+++ b/src/DentstageToolApp.Api/Services/Auth/AuthService.cs
@@ -1,0 +1,334 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using DentstageToolApp.Api.Auth;
+using DentstageToolApp.Api.Options;
+using DentstageToolApp.Infrastructure.Data;
+using DentstageToolApp.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace DentstageToolApp.Api.Services.Auth;
+
+/// <summary>
+/// 身份驗證服務實作，負責處理帳號驗證、裝置綁定與 Token 發放。
+/// </summary>
+public class AuthService : IAuthService
+{
+    private readonly DentstageToolAppContext _context;
+    private readonly JwtOptions _jwtOptions;
+    private readonly ILogger<AuthService> _logger;
+
+    /// <summary>
+    /// 預先快取 JWT Token 產生器，減少重複建立的成本。
+    /// </summary>
+    private readonly JwtSecurityTokenHandler _tokenHandler = new();
+
+    /// <summary>
+    /// 建構子，注入資料庫內容、JWT 設定與記錄器。
+    /// </summary>
+    public AuthService(
+        DentstageToolAppContext context,
+        IOptions<JwtOptions> jwtOptions,
+        ILogger<AuthService> logger)
+    {
+        _context = context;
+        _jwtOptions = jwtOptions.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<LoginResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken)
+    {
+        // 以帳號為索引進行查詢，並一併載入裝置註冊與 Token 清單，方便後續檢查狀態
+        var user = await _context.UserAccounts
+            .Include(x => x.DeviceRegistrations)
+            .Include(x => x.RefreshTokens)
+            .FirstOrDefaultAsync(x => x.Account == request.Account, cancellationToken);
+
+        if (user is null)
+        {
+            throw new AuthException(HttpStatusCode.Unauthorized, "帳號或密碼錯誤。");
+        }
+
+        if (!user.IsActive)
+        {
+            throw new AuthException(HttpStatusCode.Forbidden, "帳號已被停用，請聯絡管理員。");
+        }
+
+        if (!VerifyPassword(request.Password, user.PasswordHash))
+        {
+            throw new AuthException(HttpStatusCode.Unauthorized, "帳號或密碼錯誤。");
+        }
+
+        // 檢查或建立裝置註冊資料，確保每台裝置都有綁定紀錄
+        var device = user.DeviceRegistrations.FirstOrDefault(x => x.DeviceKey == request.DeviceKey);
+        if (device is null)
+        {
+            device = CreateDeviceRegistration(user, request);
+            await _context.DeviceRegistrations.AddAsync(device, cancellationToken);
+        }
+        else
+        {
+            UpdateDeviceMetadata(device, request);
+        }
+
+        if (device.IsBlackListed || !string.Equals(device.Status, "Active", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new AuthException(HttpStatusCode.Forbidden, "此裝置已被停用或封鎖，請洽管理員處理。");
+        }
+
+        if (device.ExpireAt.HasValue && device.ExpireAt.Value < DateTime.UtcNow)
+        {
+            throw new AuthException(HttpStatusCode.Forbidden, "裝置授權已過期，請聯絡管理員重新啟用。");
+        }
+
+        // 清理既有的過期 Refresh Token，避免資料持續累積
+        await CleanupExpiredTokensAsync(device.DeviceRegistrationUid, cancellationToken);
+
+        var now = DateTime.UtcNow;
+        var accessTokenExpireAt = now.AddMinutes(_jwtOptions.AccessTokenMinutes);
+        var refreshTokenExpireAt = now.AddDays(_jwtOptions.RefreshTokenDays);
+
+        var accessToken = GenerateAccessToken(user, device, now, accessTokenExpireAt);
+        var refreshToken = GenerateRefreshToken(user, device, refreshTokenExpireAt, now);
+
+        user.LastLoginAt = now;
+        device.LastSignInAt = now;
+        device.ExpireAt ??= refreshTokenExpireAt;
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("使用者 {Account} 從裝置 {Device} 成功登入。", user.Account, device.DeviceRegistrationUid);
+
+        return new LoginResponse
+        {
+            AccessToken = accessToken,
+            AccessTokenExpireAt = accessTokenExpireAt,
+            RefreshToken = refreshToken.Token,
+            RefreshTokenExpireAt = refreshTokenExpireAt,
+            DisplayName = user.DisplayName,
+            Role = user.Role,
+            DeviceStatus = device.Status,
+            Message = "登入成功，已發放新的權杖。"
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<LoginResponse> RefreshTokenAsync(RefreshTokenRequest request, CancellationToken cancellationToken)
+    {
+        // 先以 Token 字串尋找資料，並載入關聯資訊
+        var refreshToken = await _context.RefreshTokens
+            .Include(x => x.UserAccount)
+            .Include(x => x.DeviceRegistration)
+            .FirstOrDefaultAsync(x => x.Token == request.RefreshToken, cancellationToken);
+
+        if (refreshToken is null)
+        {
+            throw new AuthException(HttpStatusCode.Unauthorized, "Refresh Token 無效或已被撤銷。");
+        }
+
+        if (refreshToken.IsRevoked)
+        {
+            throw new AuthException(HttpStatusCode.Unauthorized, "Refresh Token 已被撤銷，請重新登入。");
+        }
+
+        if (refreshToken.ExpireAt < DateTime.UtcNow)
+        {
+            // 將過期 Token 標記為撤銷，避免重複查詢
+            refreshToken.IsRevoked = true;
+            refreshToken.RevokedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync(cancellationToken);
+            throw new AuthException(HttpStatusCode.Unauthorized, "Refresh Token 已過期，請重新登入。");
+        }
+
+        if (refreshToken.DeviceRegistration is null || refreshToken.DeviceRegistration.DeviceKey != request.DeviceKey)
+        {
+            throw new AuthException(HttpStatusCode.Unauthorized, "裝置驗證失敗，請重新登入。");
+        }
+
+        var user = refreshToken.UserAccount;
+        if (!user.IsActive)
+        {
+            throw new AuthException(HttpStatusCode.Forbidden, "帳號已被停用，請聯絡管理員。");
+        }
+
+        var device = refreshToken.DeviceRegistration;
+        if (device.IsBlackListed || !string.Equals(device.Status, "Active", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new AuthException(HttpStatusCode.Forbidden, "此裝置已被停用或封鎖。");
+        }
+
+        // 旋轉 Refresh Token：先撤銷舊的，再建立新的 Token 記錄
+        refreshToken.IsRevoked = true;
+        refreshToken.RevokedAt = DateTime.UtcNow;
+
+        var now = DateTime.UtcNow;
+        var accessTokenExpireAt = now.AddMinutes(_jwtOptions.AccessTokenMinutes);
+        var refreshTokenExpireAt = now.AddDays(_jwtOptions.RefreshTokenDays);
+
+        var accessToken = GenerateAccessToken(user, device, now, accessTokenExpireAt);
+        var newRefreshToken = GenerateRefreshToken(user, device, refreshTokenExpireAt, now);
+
+        device.LastSignInAt = now;
+        if (!device.ExpireAt.HasValue || device.ExpireAt.Value < refreshTokenExpireAt)
+        {
+            device.ExpireAt = refreshTokenExpireAt;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("使用者 {Account} 透過裝置 {Device} 更新 Token。", user.Account, device.DeviceRegistrationUid);
+
+        return new LoginResponse
+        {
+            AccessToken = accessToken,
+            AccessTokenExpireAt = accessTokenExpireAt,
+            RefreshToken = newRefreshToken.Token,
+            RefreshTokenExpireAt = refreshTokenExpireAt,
+            DisplayName = user.DisplayName,
+            Role = user.Role,
+            DeviceStatus = device.Status,
+            Message = "已更新權杖。"
+        };
+    }
+
+    /// <summary>
+    /// 根據登入資訊建立或更新裝置註冊資料。
+    /// </summary>
+    private static DeviceRegistration CreateDeviceRegistration(UserAccount user, LoginRequest request)
+    {
+        return new DeviceRegistration
+        {
+            DeviceRegistrationUid = Guid.NewGuid().ToString("N"),
+            UserUid = user.UserUid,
+            DeviceKey = request.DeviceKey,
+            DeviceName = request.DeviceName,
+            Status = "Active",
+            IsBlackListed = false,
+            CreationTimestamp = DateTime.UtcNow,
+            CreatedBy = user.Account,
+            UserAccount = user
+        };
+    }
+
+    /// <summary>
+    /// 更新既有裝置的描述資訊與最後修改時間。
+    /// </summary>
+    private static void UpdateDeviceMetadata(DeviceRegistration device, LoginRequest request)
+    {
+        device.DeviceName = request.DeviceName ?? device.DeviceName;
+        device.ModificationTimestamp = DateTime.UtcNow;
+        device.ModifiedBy = request.Account;
+    }
+
+    /// <summary>
+    /// 產生 Access Token，並設定必要的 Claims。
+    /// </summary>
+    private string GenerateAccessToken(UserAccount user, DeviceRegistration device, DateTime generatedAt, DateTime expireAt)
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtOptions.Secret));
+        var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+        // 建立 Claims，包含使用者識別與角色資訊
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.UserUid),
+            new(JwtRegisteredClaimNames.UniqueName, user.Account),
+            new("displayName", user.DisplayName ?? string.Empty),
+            new("device", device.DeviceRegistrationUid)
+        };
+
+        if (!string.IsNullOrWhiteSpace(user.Role))
+        {
+            claims.Add(new Claim(ClaimTypes.Role, user.Role));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: _jwtOptions.Issuer,
+            audience: _jwtOptions.Audience,
+            claims: claims,
+            notBefore: generatedAt,
+            expires: expireAt,
+            signingCredentials: credentials);
+
+        return _tokenHandler.WriteToken(token);
+    }
+
+    /// <summary>
+    /// 建立新的 Refresh Token 並儲存到資料庫。
+    /// </summary>
+    private RefreshToken GenerateRefreshToken(UserAccount user, DeviceRegistration device, DateTime expireAt, DateTime now)
+    {
+        var tokenString = Convert.ToBase64String(RandomNumberGenerator.GetBytes(48));
+        var refreshToken = new RefreshToken
+        {
+            RefreshTokenUid = Guid.NewGuid().ToString("N"),
+            Token = tokenString,
+            UserUid = user.UserUid,
+            DeviceRegistrationUid = device.DeviceRegistrationUid,
+            ExpireAt = expireAt,
+            CreationTimestamp = now,
+            CreatedBy = user.Account,
+            UserAccount = user,
+            DeviceRegistration = device
+        };
+
+        _context.RefreshTokens.Add(refreshToken);
+        return refreshToken;
+    }
+
+    /// <summary>
+    /// 驗證密碼是否符合資料庫儲存的雜湊值。
+    /// </summary>
+    private static bool VerifyPassword(string plainPassword, string storedHash)
+    {
+        if (string.IsNullOrWhiteSpace(storedHash))
+        {
+            return false;
+        }
+
+        // 先假設資料庫儲存 SHA256 雜湊，若比較失敗則回退至明碼比較（為舊資料相容性保留）
+        var sha256Hash = ComputeSha256Hash(plainPassword);
+        if (string.Equals(sha256Hash, storedHash, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return string.Equals(plainPassword, storedHash, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 使用 SHA256 計算雜湊字串。
+    /// </summary>
+    private static string ComputeSha256Hash(string input)
+    {
+        using var sha256 = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hashBytes = sha256.ComputeHash(bytes);
+        return Convert.ToHexString(hashBytes);
+    }
+
+    /// <summary>
+    /// 清除指定裝置已過期的 Refresh Token，避免資料庫累積垃圾資料。
+    /// </summary>
+    private async Task CleanupExpiredTokensAsync(string deviceRegistrationUid, CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var expiredTokens = await _context.RefreshTokens
+            .Where(x => x.DeviceRegistrationUid == deviceRegistrationUid && (x.ExpireAt < now || x.IsRevoked))
+            .ToListAsync(cancellationToken);
+
+        if (expiredTokens.Count == 0)
+        {
+            return;
+        }
+
+        _context.RefreshTokens.RemoveRange(expiredTokens);
+    }
+}

--- a/src/DentstageToolApp.Api/Services/Auth/IAuthService.cs
+++ b/src/DentstageToolApp.Api/Services/Auth/IAuthService.cs
@@ -1,0 +1,19 @@
+using DentstageToolApp.Api.Auth;
+
+namespace DentstageToolApp.Api.Services.Auth;
+
+/// <summary>
+/// 定義身份驗證流程所需的服務介面。
+/// </summary>
+public interface IAuthService
+{
+    /// <summary>
+    /// 執行登入流程並回傳 Token 與使用者資訊。
+    /// </summary>
+    Task<LoginResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 透過 Refresh Token 重新取得新的存取權杖。
+    /// </summary>
+    Task<LoginResponse> RefreshTokenAsync(RefreshTokenRequest request, CancellationToken cancellationToken);
+}

--- a/src/DentstageToolApp.Api/appsettings.Development.json
+++ b/src/DentstageToolApp.Api/appsettings.Development.json
@@ -10,5 +10,12 @@
   },
   "Swagger": {
     "Enabled": true
+  },
+  "Jwt": {
+    "Issuer": "DentstageToolApp",
+    "Audience": "DentstageToolApp",
+    "Secret": "DentstageToolApp-Backend-Secret-Key-DEV",
+    "AccessTokenMinutes": 30,
+    "RefreshTokenDays": 30
   }
 }

--- a/src/DentstageToolApp.Api/appsettings.json
+++ b/src/DentstageToolApp.Api/appsettings.json
@@ -14,5 +14,12 @@
     "EndpointName": "Dentstage Tool App API v1",
     "DocumentTitle": "Dentstage Tool App 後端 API 文件"
   },
+  "Jwt": {
+    "Issuer": "DentstageToolApp",
+    "Audience": "DentstageToolApp",
+    "Secret": "DentstageToolApp-Backend-Secret-Key-2024",
+    "AccessTokenMinutes": 30,
+    "RefreshTokenDays": 30
+  },
   "AllowedHosts": "*"
 }

--- a/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
+++ b/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
@@ -52,6 +52,21 @@ public class DentstageToolAppContext : DbContext
     public virtual DbSet<BlackList> BlackLists => Set<BlackList>();
 
     /// <summary>
+    /// 使用者帳號資料集。
+    /// </summary>
+    public virtual DbSet<UserAccount> UserAccounts => Set<UserAccount>();
+
+    /// <summary>
+    /// 裝置註冊資料集。
+    /// </summary>
+    public virtual DbSet<DeviceRegistration> DeviceRegistrations => Set<DeviceRegistration>();
+
+    /// <summary>
+    /// Refresh Token 資料集。
+    /// </summary>
+    public virtual DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+
+    /// <summary>
     /// 建立資料模型對應設定。
     /// </summary>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -63,6 +78,9 @@ public class DentstageToolAppContext : DbContext
         ConfigureCarBeauty(modelBuilder);
         ConfigurePhotoData(modelBuilder);
         ConfigureBlackList(modelBuilder);
+        ConfigureUserAccount(modelBuilder);
+        ConfigureDeviceRegistration(modelBuilder);
+        ConfigureRefreshToken(modelBuilder);
     }
 
     /// <summary>
@@ -98,6 +116,98 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.ConnectSameAsName)
             .HasMaxLength(10)
             .HasColumnName("ConnectSameAsName");
+    }
+
+    /// <summary>
+    /// 設定使用者帳號資料表欄位與關聯。
+    /// </summary>
+    private static void ConfigureUserAccount(ModelBuilder modelBuilder)
+    {
+        var entity = modelBuilder.Entity<UserAccount>();
+        entity.ToTable("UserAccounts");
+        entity.HasKey(e => e.UserUid);
+        entity.Property(e => e.UserUid)
+            .HasMaxLength(100)
+            .HasColumnName("UserUID");
+        entity.Property(e => e.CreatedBy).HasMaxLength(50);
+        entity.Property(e => e.ModifiedBy).HasMaxLength(50);
+        entity.Property(e => e.Account)
+            .IsRequired()
+            .HasMaxLength(100);
+        entity.Property(e => e.PasswordHash)
+            .IsRequired()
+            .HasMaxLength(200);
+        entity.Property(e => e.DisplayName).HasMaxLength(100);
+        entity.Property(e => e.Role).HasMaxLength(50);
+        entity.HasIndex(e => e.Account)
+            .IsUnique();
+        entity.HasMany(e => e.DeviceRegistrations)
+            .WithOne(e => e.UserAccount)
+            .HasForeignKey(e => e.UserUid)
+            .OnDelete(DeleteBehavior.Cascade);
+        entity.HasMany(e => e.RefreshTokens)
+            .WithOne(e => e.UserAccount)
+            .HasForeignKey(e => e.UserUid)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+
+    /// <summary>
+    /// 設定裝置註冊資料表欄位與關聯。
+    /// </summary>
+    private static void ConfigureDeviceRegistration(ModelBuilder modelBuilder)
+    {
+        var entity = modelBuilder.Entity<DeviceRegistration>();
+        entity.ToTable("DeviceRegistrations");
+        entity.HasKey(e => e.DeviceRegistrationUid);
+        entity.Property(e => e.DeviceRegistrationUid)
+            .HasMaxLength(100)
+            .HasColumnName("DeviceRegistrationUID");
+        entity.Property(e => e.UserUid)
+            .IsRequired()
+            .HasMaxLength(100)
+            .HasColumnName("UserUID");
+        entity.Property(e => e.DeviceKey)
+            .IsRequired()
+            .HasMaxLength(150);
+        entity.Property(e => e.DeviceName).HasMaxLength(100);
+        entity.Property(e => e.Status)
+            .IsRequired()
+            .HasMaxLength(20);
+        entity.Property(e => e.CreatedBy).HasMaxLength(50);
+        entity.Property(e => e.ModifiedBy).HasMaxLength(50);
+        entity.HasIndex(e => new { e.UserUid, e.DeviceKey })
+            .IsUnique();
+        entity.HasMany(e => e.RefreshTokens)
+            .WithOne(e => e.DeviceRegistration)
+            .HasForeignKey(e => e.DeviceRegistrationUid)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+
+    /// <summary>
+    /// 設定 Refresh Token 資料表欄位與關聯。
+    /// </summary>
+    private static void ConfigureRefreshToken(ModelBuilder modelBuilder)
+    {
+        var entity = modelBuilder.Entity<RefreshToken>();
+        entity.ToTable("RefreshTokens");
+        entity.HasKey(e => e.RefreshTokenUid);
+        entity.Property(e => e.RefreshTokenUid)
+            .HasMaxLength(100)
+            .HasColumnName("RefreshTokenUID");
+        entity.Property(e => e.Token)
+            .IsRequired()
+            .HasMaxLength(500);
+        entity.Property(e => e.UserUid)
+            .IsRequired()
+            .HasMaxLength(100)
+            .HasColumnName("UserUID");
+        entity.Property(e => e.DeviceRegistrationUid)
+            .HasMaxLength(100)
+            .HasColumnName("DeviceRegistrationUID");
+        entity.Property(e => e.CreatedBy).HasMaxLength(50);
+        entity.Property(e => e.ModifiedBy).HasMaxLength(50);
+        entity.HasIndex(e => e.Token)
+            .IsUnique();
     }
 
     /// <summary>

--- a/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
+++ b/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
@@ -131,16 +131,8 @@ public class DentstageToolAppContext : DbContext
             .HasColumnName("UserUID");
         entity.Property(e => e.CreatedBy).HasMaxLength(50);
         entity.Property(e => e.ModifiedBy).HasMaxLength(50);
-        entity.Property(e => e.Account)
-            .IsRequired()
-            .HasMaxLength(100);
-        entity.Property(e => e.PasswordHash)
-            .IsRequired()
-            .HasMaxLength(200);
         entity.Property(e => e.DisplayName).HasMaxLength(100);
         entity.Property(e => e.Role).HasMaxLength(50);
-        entity.HasIndex(e => e.Account)
-            .IsUnique();
         entity.HasMany(e => e.DeviceRegistrations)
             .WithOne(e => e.UserAccount)
             .HasForeignKey(e => e.UserUid)

--- a/src/DentstageToolApp.Infrastructure/Entities/DeviceRegistration.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/DeviceRegistration.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+
+namespace DentstageToolApp.Infrastructure.Entities;
+
+/// <summary>
+/// 裝置註冊資料實體，負責記錄裝置機碼與狀態資訊。
+/// </summary>
+public class DeviceRegistration
+{
+    /// <summary>
+    /// 建立時間戳記，掌握註冊建立時間。
+    /// </summary>
+    public DateTime? CreationTimestamp { get; set; }
+
+    /// <summary>
+    /// 建立人員資訊，預設為系統帳號。
+    /// </summary>
+    public string? CreatedBy { get; set; }
+
+    /// <summary>
+    /// 修改時間戳記，追蹤最後一次修改。
+    /// </summary>
+    public DateTime? ModificationTimestamp { get; set; }
+
+    /// <summary>
+    /// 修改人員資訊。
+    /// </summary>
+    public string? ModifiedBy { get; set; }
+
+    /// <summary>
+    /// 裝置註冊唯一識別碼，作為資料表主鍵。
+    /// </summary>
+    public string DeviceRegistrationUid { get; set; } = null!;
+
+    /// <summary>
+    /// 所屬使用者主鍵。
+    /// </summary>
+    public string UserUid { get; set; } = null!;
+
+    /// <summary>
+    /// 裝置機碼，App 啟動時會上傳比對。
+    /// </summary>
+    public string DeviceKey { get; set; } = null!;
+
+    /// <summary>
+    /// 裝置名稱或簡短描述，方便後台辨識。
+    /// </summary>
+    public string? DeviceName { get; set; }
+
+    /// <summary>
+    /// 裝置狀態，例如 Active、Disabled。
+    /// </summary>
+    public string Status { get; set; } = "Active";
+
+    /// <summary>
+    /// 裝置是否被標記為封鎖。
+    /// </summary>
+    public bool IsBlackListed { get; set; }
+
+    /// <summary>
+    /// 裝置最後登入時間，方便檢查閒置狀態。
+    /// </summary>
+    public DateTime? LastSignInAt { get; set; }
+
+    /// <summary>
+    /// 裝置註冊過期時間，超過需要重新登入。
+    /// </summary>
+    public DateTime? ExpireAt { get; set; }
+
+    /// <summary>
+    /// 所屬使用者導覽屬性。
+    /// </summary>
+    public UserAccount UserAccount { get; set; } = null!;
+
+    /// <summary>
+    /// 裝置發出的 Refresh Token 清單。
+    /// </summary>
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
+}

--- a/src/DentstageToolApp.Infrastructure/Entities/RefreshToken.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/RefreshToken.cs
@@ -1,0 +1,79 @@
+using System;
+
+namespace DentstageToolApp.Infrastructure.Entities;
+
+/// <summary>
+/// Refresh Token 實體，負責記錄長期登入授權資料。
+/// </summary>
+public class RefreshToken
+{
+    /// <summary>
+    /// 建立時間戳記。
+    /// </summary>
+    public DateTime? CreationTimestamp { get; set; }
+
+    /// <summary>
+    /// 建立人員或系統來源。
+    /// </summary>
+    public string? CreatedBy { get; set; }
+
+    /// <summary>
+    /// 修改時間戳記。
+    /// </summary>
+    public DateTime? ModificationTimestamp { get; set; }
+
+    /// <summary>
+    /// 修改人員資訊。
+    /// </summary>
+    public string? ModifiedBy { get; set; }
+
+    /// <summary>
+    /// Refresh Token 主鍵。
+    /// </summary>
+    public string RefreshTokenUid { get; set; } = null!;
+
+    /// <summary>
+    /// Token 字串內容。
+    /// </summary>
+    public string Token { get; set; } = null!;
+
+    /// <summary>
+    /// Token 所屬使用者主鍵。
+    /// </summary>
+    public string UserUid { get; set; } = null!;
+
+    /// <summary>
+    /// 產生 Token 的裝置註冊主鍵，可為空代表系統操作。
+    /// </summary>
+    public string? DeviceRegistrationUid { get; set; }
+
+    /// <summary>
+    /// Token 過期時間。
+    /// </summary>
+    public DateTime ExpireAt { get; set; }
+
+    /// <summary>
+    /// 最後使用時間，用於分析使用情況。
+    /// </summary>
+    public DateTime? LastUsedAt { get; set; }
+
+    /// <summary>
+    /// 是否已被撤銷，撤銷後不可再使用。
+    /// </summary>
+    public bool IsRevoked { get; set; }
+
+    /// <summary>
+    /// 撤銷時間，配合 IsRevoked 使用。
+    /// </summary>
+    public DateTime? RevokedAt { get; set; }
+
+    /// <summary>
+    /// 導覽屬性：Token 所屬使用者。
+    /// </summary>
+    public UserAccount UserAccount { get; set; } = null!;
+
+    /// <summary>
+    /// 導覽屬性：產生 Token 的裝置註冊資料。
+    /// </summary>
+    public DeviceRegistration? DeviceRegistration { get; set; }
+}

--- a/src/DentstageToolApp.Infrastructure/Entities/UserAccount.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/UserAccount.cs
@@ -34,16 +34,6 @@ public class UserAccount
     public string UserUid { get; set; } = null!;
 
     /// <summary>
-    /// 帳號名稱，供登入時輸入使用。
-    /// </summary>
-    public string Account { get; set; } = null!;
-
-    /// <summary>
-    /// 密碼雜湊值，採用雜湊後字串而非明碼保存。
-    /// </summary>
-    public string PasswordHash { get; set; } = null!;
-
-    /// <summary>
     /// 顯示名稱，提供前端顯示使用。
     /// </summary>
     public string? DisplayName { get; set; }

--- a/src/DentstageToolApp.Infrastructure/Entities/UserAccount.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/UserAccount.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace DentstageToolApp.Infrastructure.Entities;
+
+/// <summary>
+/// 使用者帳號主檔實體，負責保存登入驗證所需的基礎資料。
+/// </summary>
+public class UserAccount
+{
+    /// <summary>
+    /// 建立時間戳記，方便追蹤帳號建立時間。
+    /// </summary>
+    public DateTime? CreationTimestamp { get; set; }
+
+    /// <summary>
+    /// 建立人員，記錄是由哪位管理者新增資料。
+    /// </summary>
+    public string? CreatedBy { get; set; }
+
+    /// <summary>
+    /// 最後修改時間戳記，掌握最近一次異動時間。
+    /// </summary>
+    public DateTime? ModificationTimestamp { get; set; }
+
+    /// <summary>
+    /// 最後修改人員資訊。
+    /// </summary>
+    public string? ModifiedBy { get; set; }
+
+    /// <summary>
+    /// 使用者唯一識別碼，作為資料表主鍵。
+    /// </summary>
+    public string UserUid { get; set; } = null!;
+
+    /// <summary>
+    /// 帳號名稱，供登入時輸入使用。
+    /// </summary>
+    public string Account { get; set; } = null!;
+
+    /// <summary>
+    /// 密碼雜湊值，採用雜湊後字串而非明碼保存。
+    /// </summary>
+    public string PasswordHash { get; set; } = null!;
+
+    /// <summary>
+    /// 顯示名稱，提供前端顯示使用。
+    /// </summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// 使用者角色資訊，決定權限等級。
+    /// </summary>
+    public string? Role { get; set; }
+
+    /// <summary>
+    /// 帳號是否啟用中，若為 False 代表無法登入。
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// 最後一次成功登入時間，用於統計或安全稽核。
+    /// </summary>
+    public DateTime? LastLoginAt { get; set; }
+
+    /// <summary>
+    /// 使用者名下的裝置註冊清單。
+    /// </summary>
+    public ICollection<DeviceRegistration> DeviceRegistrations { get; set; } = new List<DeviceRegistration>();
+
+    /// <summary>
+    /// 使用者所擁有的 Refresh Token 清單。
+    /// </summary>
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
+}


### PR DESCRIPTION
## 摘要
- 新增使用者帳號、裝置註冊與 Refresh Token 實體，並於資料庫內容類別設定對應關聯。
- 建立身份驗證服務與 AuthController，提供登入與刷新權杖 API，並整合 JWT 組態與驗證。
- 新增 Refresh Token 清理背景服務，並於應用程式啟用身份驗證與授權管線。

## 測試
- 由於環境缺少 dotnet 指令，無法執行建置驗證。

------
https://chatgpt.com/codex/tasks/task_e_68db5141a1c8832494efaf5fddfd1d40