### PR TITLE
新增 POST 估價單列表查詢 API

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -45,6 +45,25 @@ public class QuotationsController : ControllerBase
         return Ok(quotations);
     }
 
+    /// <summary>
+    /// 透過 POST 傳遞查詢條件以取得估價單列表，適合參數較多或需要 Body 傳遞時使用。
+    /// </summary>
+    /// <param name="request">查詢參數，與 GET 版本相同但由 Body 傳遞。</param>
+    /// <param name="cancellationToken">取消權杖，供前端於離開頁面時停止查詢。</param>
+    [HttpPost]
+    [ProducesResponseType(typeof(QuotationListResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<QuotationListResponse>> SearchQuotationsAsync([FromBody] QuotationListQuery request, CancellationToken cancellationToken)
+    {
+        // 若 Body 未帶入資料，建立預設查詢參數避免空參考例外。
+        var query = request ?? new QuotationListQuery();
+
+        _logger.LogDebug("POST 查詢估價單列表，參數：{@Query}", query);
+
+        var quotations = await _quotationService.GetQuotationsAsync(query, cancellationToken);
+
+        return Ok(quotations);
+    }
+
     // ---------- 方法區 ----------
     // 目前無額外私有方法，預留區塊供後續擴充篩選或轉換邏輯。
 


### PR DESCRIPTION
## 摘要
- 新增 POST 版本的估價單列表查詢端點，支援以 Body 傳遞搜尋條件
- 於控制器內補充請求為空時的預設處理與除錯記錄，強化穩定性

## 測試
- 未執行自動化測試（需求允許直接提交）

------
https://chatgpt.com/codex/tasks/task_e_68db9e5f199883249445fc617d29c3cb