### PR TITLE
新增車輛資料建立 API

### DIFF
--- a/src/DentstageToolApp.Api/Cars/CreateCarRequest.cs
+++ b/src/DentstageToolApp.Api/Cars/CreateCarRequest.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Cars;
+
+/// <summary>
+/// 新增車輛資料時所需的輸入欄位定義。
+/// </summary>
+public class CreateCarRequest
+{
+    /// <summary>
+    /// 車牌號碼，支援帶入破折號或空白，會在服務內統一轉成大寫後再儲存。
+    /// </summary>
+    [Required(ErrorMessage = "請輸入車牌號碼。")]
+    [StringLength(50, ErrorMessage = "車牌號碼長度不得超過 50 個字元。")]
+    public string? LicensePlateNumber { get; set; }
+
+    /// <summary>
+    /// 車輛品牌或車款資訊，可留空。
+    /// </summary>
+    [StringLength(50, ErrorMessage = "車輛品牌長度不得超過 50 個字元。")]
+    public string? Brand { get; set; }
+
+    /// <summary>
+    /// 車輛型號，可留空。
+    /// </summary>
+    [StringLength(50, ErrorMessage = "車輛型號長度不得超過 50 個字元。")]
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// 車色，可留空。
+    /// </summary>
+    [StringLength(50, ErrorMessage = "車色長度不得超過 50 個字元。")]
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// 車輛備註，紀錄維修人員補充說明。
+    /// </summary>
+    [StringLength(255, ErrorMessage = "備註長度不得超過 255 個字元。")]
+    public string? Remark { get; set; }
+
+    /// <summary>
+    /// 操作人員名稱，若未填寫會以系統帳號代替。
+    /// </summary>
+    [StringLength(50, ErrorMessage = "操作人員名稱長度不得超過 50 個字元。")]
+    public string? OperatorName { get; set; }
+}

--- a/src/DentstageToolApp.Api/Cars/CreateCarResponse.cs
+++ b/src/DentstageToolApp.Api/Cars/CreateCarResponse.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace DentstageToolApp.Api.Cars;
+
+/// <summary>
+/// 新增車輛成功後回傳給前端的結果資訊。
+/// </summary>
+public class CreateCarResponse
+{
+    /// <summary>
+    /// 車輛主鍵識別碼，供後續編輯或查詢使用。
+    /// </summary>
+    public string CarUid { get; set; } = null!;
+
+    /// <summary>
+    /// 車牌號碼，會維持使用者輸入的大寫格式。
+    /// </summary>
+    public string LicensePlateNumber { get; set; } = null!;
+
+    /// <summary>
+    /// 車輛品牌或車款資訊。
+    /// </summary>
+    public string? Brand { get; set; }
+
+    /// <summary>
+    /// 車輛型號資訊。
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// 車色。
+    /// </summary>
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// 車輛備註。
+    /// </summary>
+    public string? Remark { get; set; }
+
+    /// <summary>
+    /// 建立時間，以 UTC 儲存供前端轉換時區。
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// 人類可讀的提示訊息，方便前端直接顯示。
+    /// </summary>
+    public string Message { get; set; } = null!;
+}

--- a/src/DentstageToolApp.Api/Controllers/CarsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/CarsController.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Cars;
+using DentstageToolApp.Api.Services.Car;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Controllers;
+
+/// <summary>
+/// 車輛維運 API，提供新增車輛的資料入口。
+/// </summary>
+[ApiController]
+[Route("api/cars")]
+[Authorize]
+public class CarsController : ControllerBase
+{
+    private readonly ICarManagementService _carManagementService;
+    private readonly ILogger<CarsController> _logger;
+
+    /// <summary>
+    /// 建構子，注入車輛維運服務與記錄器。
+    /// </summary>
+    public CarsController(ICarManagementService carManagementService, ILogger<CarsController> logger)
+    {
+        _carManagementService = carManagementService;
+        _logger = logger;
+    }
+
+    // ---------- API 呼叫區 ----------
+
+    /// <summary>
+    /// 新增車輛資料，建立車牌、品牌、型號與備註等欄位。
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(CreateCarResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<CreateCarResponse>> CreateCarAsync([FromBody] CreateCarRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            // ModelState 會帶有詳細欄位錯誤，直接回傳標準 ProblemDetails。
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var response = await _carManagementService.CreateCarAsync(request, cancellationToken);
+            return StatusCode(StatusCodes.Status201Created, response);
+        }
+        catch (CarManagementException ex)
+        {
+            _logger.LogWarning(ex, "新增車輛失敗：{Message}", ex.Message);
+            return BuildProblemDetails(ex.StatusCode, ex.Message, "新增車輛資料失敗");
+        }
+        catch (OperationCanceledException)
+        {
+            // 前端可能在等待時取消請求，寫入記錄後回傳 499 狀態碼資訊。
+            _logger.LogInformation("新增車輛流程被取消。");
+            return BuildProblemDetails((HttpStatusCode)499, "請求已取消，資料未異動。", "新增車輛資料已取消");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "新增車輛流程發生未預期錯誤。");
+            return BuildProblemDetails(HttpStatusCode.InternalServerError, "系統處理請求時發生錯誤，請稍後再試。", "新增車輛資料失敗");
+        }
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 將例外轉換成 ProblemDetails，統一錯誤輸出格式。
+    /// </summary>
+    private ActionResult BuildProblemDetails(HttpStatusCode statusCode, string message, string title)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = (int)statusCode,
+            Title = title,
+            Detail = message,
+            Instance = HttpContext.Request.Path
+        };
+
+        return StatusCode(problem.Status ?? StatusCodes.Status500InternalServerError, problem);
+    }
+
+    // ---------- 生命週期 ----------
+    // 控制器目前沒有額外生命週期事件，保留區塊以符合專案規範。
+}

--- a/src/DentstageToolApp.Api/Program.cs
+++ b/src/DentstageToolApp.Api/Program.cs
@@ -6,6 +6,7 @@ using DentstageToolApp.Api.BackgroundJobs;
 using DentstageToolApp.Api.Options;
 using DentstageToolApp.Api.Services.Admin;
 using DentstageToolApp.Api.Services.Auth;
+using DentstageToolApp.Api.Services.Car;
 using DentstageToolApp.Api.Services.CarPlate;
 using DentstageToolApp.Api.Services.Quotation;
 using DentstageToolApp.Infrastructure.Data;
@@ -139,6 +140,7 @@ builder.Services.AddScoped<IAccountAdminService, AccountAdminService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IQuotationService, QuotationService>();
 builder.Services.AddScoped<ICarPlateRecognitionService, CarPlateRecognitionService>();
+builder.Services.AddScoped<ICarManagementService, CarManagementService>();
 builder.Services.AddHostedService<RefreshTokenCleanupService>();
 
 var app = builder.Build();

--- a/src/DentstageToolApp.Api/Services/Car/CarManagementException.cs
+++ b/src/DentstageToolApp.Api/Services/Car/CarManagementException.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Net;
+
+namespace DentstageToolApp.Api.Services.Car;
+
+/// <summary>
+/// 車輛維運相關操作失敗時所拋出的自訂例外，方便對應 HTTP 狀態碼。
+/// </summary>
+public class CarManagementException : Exception
+{
+    /// <summary>
+    /// 失敗時對應的 HTTP 狀態碼。
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// 建立例外並指派狀態碼與錯誤訊息。
+    /// </summary>
+    public CarManagementException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}

--- a/src/DentstageToolApp.Api/Services/Car/CarManagementService.cs
+++ b/src/DentstageToolApp.Api/Services/Car/CarManagementService.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Cars;
+using DentstageToolApp.Infrastructure.Data;
+using DentstageToolApp.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Services.Car;
+
+/// <summary>
+/// 車輛維運服務實作，負責處理新增車輛的資料清理與儲存流程。
+/// </summary>
+public class CarManagementService : ICarManagementService
+{
+    private readonly DentstageToolAppContext _dbContext;
+    private readonly ILogger<CarManagementService> _logger;
+
+    /// <summary>
+    /// 建構子，注入資料庫內容物件與記錄器。
+    /// </summary>
+    public CarManagementService(DentstageToolAppContext dbContext, ILogger<CarManagementService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<CreateCarResponse> CreateCarAsync(CreateCarRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            throw new CarManagementException(HttpStatusCode.BadRequest, "請提供車輛建立資料。");
+        }
+
+        // ---------- 參數整理區 ----------
+        var licensePlate = (request.LicensePlateNumber ?? string.Empty).Trim();
+        var normalizedPlate = NormalizePlate(licensePlate);
+
+        if (string.IsNullOrWhiteSpace(licensePlate) || string.IsNullOrWhiteSpace(normalizedPlate))
+        {
+            // 若輸入全為空白或無法解析出有效車牌，直接回報錯誤避免寫入髒資料。
+            throw new CarManagementException(HttpStatusCode.BadRequest, "車牌號碼格式不正確，請確認僅輸入英數字。");
+        }
+
+        var storedPlate = licensePlate.ToUpperInvariant();
+        var brand = NormalizeOptionalText(request.Brand);
+        var model = NormalizeOptionalText(request.Model);
+        var color = NormalizeOptionalText(request.Color);
+        var remark = NormalizeOptionalText(request.Remark);
+        var operatorName = string.IsNullOrWhiteSpace(request.OperatorName)
+            ? "CarAPI"
+            : request.OperatorName!.Trim();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // ---------- 資料檢核區 ----------
+        var exists = await _dbContext.Cars
+            .AsNoTracking()
+            .AnyAsync(car =>
+                car.CarNo == storedPlate
+                || car.CarNo == normalizedPlate
+                || car.CarNoQuery == normalizedPlate
+                || car.CarNoQuery == storedPlate,
+                cancellationToken);
+
+        if (exists)
+        {
+            _logger.LogWarning("新增車輛失敗，車牌 {LicensePlate} 已存在。", storedPlate);
+            throw new CarManagementException(HttpStatusCode.Conflict, "車牌號碼已存在，請勿重複建立。");
+        }
+
+        // ---------- 實體建立區 ----------
+        var now = DateTime.UtcNow;
+        var carEntity = new Car
+        {
+            CarUid = Guid.NewGuid().ToString("N"),
+            CarNo = storedPlate,
+            CarNoQuery = normalizedPlate,
+            Brand = brand,
+            Model = model,
+            Color = color,
+            CarRemark = remark,
+            BrandModel = BuildBrandModel(brand, model),
+            CreationTimestamp = now,
+            CreatedBy = operatorName,
+            ModificationTimestamp = now,
+            ModifiedBy = operatorName
+        };
+
+        await _dbContext.Cars.AddAsync(carEntity, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("操作人員 {Operator} 建立車輛 {CarUid} ({Plate}) 成功。", operatorName, carEntity.CarUid, storedPlate);
+
+        // ---------- 組裝回應區 ----------
+        return new CreateCarResponse
+        {
+            CarUid = carEntity.CarUid,
+            LicensePlateNumber = carEntity.CarNo,
+            Brand = carEntity.Brand,
+            Model = carEntity.Model,
+            Color = carEntity.Color,
+            Remark = carEntity.CarRemark,
+            CreatedAt = now,
+            Message = "已建立車輛資料。"
+        };
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 將輸入車牌字串轉成僅包含英數字的大寫格式，方便搜尋與比對。
+    /// </summary>
+    private static string NormalizePlate(string plate)
+    {
+        if (string.IsNullOrWhiteSpace(plate))
+        {
+            return string.Empty;
+        }
+
+        var filtered = new string(plate.Where(char.IsLetterOrDigit).ToArray());
+        return filtered.ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// 處理可選文字欄位，若為空則回傳 null，避免寫入多餘空白。
+    /// </summary>
+    private static string? NormalizeOptionalText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+
+    /// <summary>
+    /// 建立品牌與型號的合併欄位，供後端查詢使用。
+    /// </summary>
+    private static string? BuildBrandModel(string? brand, string? model)
+    {
+        if (string.IsNullOrWhiteSpace(brand) && string.IsNullOrWhiteSpace(model))
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(brand))
+        {
+            return model;
+        }
+
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            return brand;
+        }
+
+        return $"{brand} {model}";
+    }
+}

--- a/src/DentstageToolApp.Api/Services/Car/ICarManagementService.cs
+++ b/src/DentstageToolApp.Api/Services/Car/ICarManagementService.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Cars;
+
+namespace DentstageToolApp.Api.Services.Car;
+
+/// <summary>
+/// 車輛維運服務介面，定義新增車輛所需的方法。
+/// </summary>
+public interface ICarManagementService
+{
+    /// <summary>
+    /// 新增車輛基本資料，會檢查車牌是否重複並自動正規化格式。
+    /// </summary>
+    /// <param name="request">車輛建立請求內容。</param>
+    /// <param name="cancellationToken">取消權杖，用於中止長時間操作。</param>
+    /// <returns>建立成功後的車輛資訊。</returns>
+    Task<CreateCarResponse> CreateCarAsync(CreateCarRequest request, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## 摘要
- 建立 CarsController 並提供受權限保護的車輛新增端點
- 新增車輛建立請求與回應模型，擴充服務層處理車牌正規化與重複檢核
- 註冊車輛維運服務供相依性注入，寫入資料庫後回傳操作結果

## 測試
- 環境未安裝 dotnet CLI，無法執行 dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68dc847ac7f88324807c71ec48960b84