### PR TITLE
調整新增車輛 API 欄位與權限資訊

### DIFF
--- a/src/DentstageToolApp.Api/Cars/CreateCarRequest.cs
+++ b/src/DentstageToolApp.Api/Cars/CreateCarRequest.cs
@@ -12,19 +12,19 @@ public class CreateCarRequest
     /// </summary>
     [Required(ErrorMessage = "請輸入車牌號碼。")]
     [StringLength(50, ErrorMessage = "車牌號碼長度不得超過 50 個字元。")]
-    public string? LicensePlateNumber { get; set; }
+    public string? CarPlateNumber { get; set; }
 
     /// <summary>
-    /// 車輛品牌或車款資訊，可留空。
+    /// 車輛品牌識別碼，需由前端傳入既有的品牌編號，若無則留空。
     /// </summary>
-    [StringLength(50, ErrorMessage = "車輛品牌長度不得超過 50 個字元。")]
-    public string? Brand { get; set; }
+    [Range(1, int.MaxValue, ErrorMessage = "品牌識別碼需大於 0。")]
+    public int? BrandId { get; set; }
 
     /// <summary>
-    /// 車輛型號，可留空。
+    /// 車輛型號識別碼，需搭配品牌編號進行檢核，可留空。
     /// </summary>
-    [StringLength(50, ErrorMessage = "車輛型號長度不得超過 50 個字元。")]
-    public string? Model { get; set; }
+    [Range(1, int.MaxValue, ErrorMessage = "車型識別碼需大於 0。")]
+    public int? ModelId { get; set; }
 
     /// <summary>
     /// 車色，可留空。
@@ -38,9 +38,4 @@ public class CreateCarRequest
     [StringLength(255, ErrorMessage = "備註長度不得超過 255 個字元。")]
     public string? Remark { get; set; }
 
-    /// <summary>
-    /// 操作人員名稱，若未填寫會以系統帳號代替。
-    /// </summary>
-    [StringLength(50, ErrorMessage = "操作人員名稱長度不得超過 50 個字元。")]
-    public string? OperatorName { get; set; }
 }

--- a/src/DentstageToolApp.Api/Cars/CreateCarResponse.cs
+++ b/src/DentstageToolApp.Api/Cars/CreateCarResponse.cs
@@ -15,7 +15,12 @@ public class CreateCarResponse
     /// <summary>
     /// 車牌號碼，會維持使用者輸入的大寫格式。
     /// </summary>
-    public string LicensePlateNumber { get; set; } = null!;
+    public string CarPlateNumber { get; set; } = null!;
+
+    /// <summary>
+    /// 車輛品牌識別碼，回傳前端所選品牌，若未指定則為 null。
+    /// </summary>
+    public int? BrandId { get; set; }
 
     /// <summary>
     /// 車輛品牌或車款資訊。
@@ -26,6 +31,11 @@ public class CreateCarResponse
     /// 車輛型號資訊。
     /// </summary>
     public string? Model { get; set; }
+
+    /// <summary>
+    /// 車輛型號識別碼，回傳前端所選型號，若未指定則為 null。
+    /// </summary>
+    public int? ModelId { get; set; }
 
     /// <summary>
     /// 車色。

--- a/src/DentstageToolApp.Api/Services/Car/ICarManagementService.cs
+++ b/src/DentstageToolApp.Api/Services/Car/ICarManagementService.cs
@@ -13,8 +13,9 @@ public interface ICarManagementService
     /// 新增車輛基本資料，會檢查車牌是否重複並自動正規化格式。
     /// </summary>
     /// <param name="request">車輛建立請求內容。</param>
+    /// <param name="operatorName">操作人員名稱，將由 JWT 使用者資訊帶入。</param>
     /// <param name="cancellationToken">取消權杖，用於中止長時間操作。</param>
     /// <returns>建立成功後的車輛資訊。</returns>
-    Task<CreateCarResponse> CreateCarAsync(CreateCarRequest request, CancellationToken cancellationToken);
+    Task<CreateCarResponse> CreateCarAsync(CreateCarRequest request, string operatorName, CancellationToken cancellationToken);
 
 }


### PR DESCRIPTION
## 摘要
- 新增車輛請求改用 CarPlateNumber 並以品牌、車型識別碼寫入資料
- 新增車輛服務改寫為使用 JWT 使用者填入建立與修改資訊，並統一產生 Ca_{uuid} 格式主鍵
- API 控制器改以 JWT Claims 取得操作人員名稱並回傳品牌與車型識別碼

## 測試
- dotnet build（環境缺少 dotnet 指令，無法執行）

------
https://chatgpt.com/codex/tasks/task_e_68dcd2b4fc608324985bd6e4fa105c6c