### PR TITLE
新增客戶資料建立 API 與服務

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/CustomersController.cs
+++ b/src/DentstageToolApp.Api/Controllers/CustomersController.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Customers;
+using DentstageToolApp.Api.Services.Customer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Controllers;
+
+/// <summary>
+/// 客戶維運 API，提供新增客戶的資料入口。
+/// </summary>
+[ApiController]
+[Route("api/customers")]
+[Authorize]
+public class CustomersController : ControllerBase
+{
+    private readonly ICustomerManagementService _customerManagementService;
+    private readonly ILogger<CustomersController> _logger;
+
+    /// <summary>
+    /// 建構子，注入客戶維運服務與記錄器。
+    /// </summary>
+    public CustomersController(ICustomerManagementService customerManagementService, ILogger<CustomersController> logger)
+    {
+        _customerManagementService = customerManagementService;
+        _logger = logger;
+    }
+
+    // ---------- API 呼叫區 ----------
+
+    /// <summary>
+    /// 新增客戶資料，建立姓名、電話、來源與備註等欄位。
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(CreateCustomerResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<CreateCustomerResponse>> CreateCustomerAsync([FromBody] CreateCustomerRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            // ModelState 會帶有詳細欄位錯誤，直接回傳標準 ProblemDetails。
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            // 透過 JWT 取得操作人員名稱，統一填寫建立與修改者資訊。
+            var operatorName = GetCurrentOperatorName();
+            var response = await _customerManagementService.CreateCustomerAsync(request, operatorName, cancellationToken);
+            return StatusCode(StatusCodes.Status201Created, response);
+        }
+        catch (CustomerManagementException ex)
+        {
+            _logger.LogWarning(ex, "新增客戶失敗：{Message}", ex.Message);
+            return BuildProblemDetails(ex.StatusCode, ex.Message, "新增客戶資料失敗");
+        }
+        catch (OperationCanceledException)
+        {
+            // 前端可能在等待時取消請求，寫入記錄後回傳 499 狀態碼資訊。
+            _logger.LogInformation("新增客戶流程被取消。");
+            return BuildProblemDetails((HttpStatusCode)499, "請求已取消，資料未異動。", "新增客戶資料已取消");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "新增客戶流程發生未預期錯誤。");
+            return BuildProblemDetails(HttpStatusCode.InternalServerError, "系統處理請求時發生錯誤，請稍後再試。", "新增客戶資料失敗");
+        }
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 將例外轉換成 ProblemDetails，統一錯誤輸出格式。
+    /// </summary>
+    private ActionResult BuildProblemDetails(HttpStatusCode statusCode, string message, string title)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = (int)statusCode,
+            Title = title,
+            Detail = message,
+            Instance = HttpContext.Request.Path
+        };
+
+        return StatusCode(problem.Status ?? StatusCodes.Status500InternalServerError, problem);
+    }
+
+    /// <summary>
+    /// 從 JWT 權杖中取得操作人員名稱，優先使用顯示名稱，再回退至使用者識別碼。
+    /// </summary>
+    private string GetCurrentOperatorName()
+    {
+        // 先取 displayName Claim，確保記錄可讀性。
+        var displayName = User.FindFirstValue("displayName");
+        if (!string.IsNullOrWhiteSpace(displayName))
+        {
+            return displayName;
+        }
+
+        // 若無顯示名稱則改用 Sub 或 UniqueName 以確保可追蹤性。
+        var userUid = User.FindFirstValue(JwtRegisteredClaimNames.Sub);
+        if (!string.IsNullOrWhiteSpace(userUid))
+        {
+            return userUid;
+        }
+
+        userUid = User.FindFirstValue(JwtRegisteredClaimNames.UniqueName);
+        if (!string.IsNullOrWhiteSpace(userUid))
+        {
+            return userUid;
+        }
+
+        // 最後使用通用 NameIdentifier，避免回傳空字串造成資料庫寫入失敗。
+        userUid = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return string.IsNullOrWhiteSpace(userUid) ? "UnknownUser" : userUid;
+    }
+
+    // ---------- 生命週期 ----------
+    // 控制器目前沒有額外生命週期事件，保留區塊以符合專案規範。
+}

--- a/src/DentstageToolApp.Api/Customers/CreateCustomerRequest.cs
+++ b/src/DentstageToolApp.Api/Customers/CreateCustomerRequest.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Customers;
+
+/// <summary>
+/// 建立客戶資料時的輸入欄位定義，確保傳入資料符合資料庫欄位限制。
+/// </summary>
+public class CreateCustomerRequest
+{
+    /// <summary>
+    /// 客戶名稱，為必填欄位。
+    /// </summary>
+    [Required(ErrorMessage = "請輸入客戶名稱。")]
+    [StringLength(100, ErrorMessage = "客戶名稱長度不得超過 100 個字元。")]
+    public string? CustomerName { get; set; }
+
+    /// <summary>
+    /// 聯絡電話，可留空但若有填寫需符合長度限制。
+    /// </summary>
+    [StringLength(20, ErrorMessage = "聯絡電話長度不得超過 20 個字元。")]
+    public string? Phone { get; set; }
+
+    /// <summary>
+    /// 客戶類別（例如一般客戶、企業客戶等）。
+    /// </summary>
+    [StringLength(50, ErrorMessage = "客戶類別長度不得超過 50 個字元。")]
+    public string? Category { get; set; }
+
+    /// <summary>
+    /// 客戶性別，採用前端約定的值（例如 Male、Female）。
+    /// </summary>
+    [StringLength(10, ErrorMessage = "性別長度不得超過 10 個字元。")]
+    public string? Gender { get; set; }
+
+    /// <summary>
+    /// 所在縣市資訊。
+    /// </summary>
+    [StringLength(50, ErrorMessage = "縣市長度不得超過 50 個字元。")]
+    public string? County { get; set; }
+
+    /// <summary>
+    /// 所在區域或鄉鎮。
+    /// </summary>
+    [StringLength(50, ErrorMessage = "區域長度不得超過 50 個字元。")]
+    public string? Township { get; set; }
+
+    /// <summary>
+    /// 電子郵件，會在服務層再做進一步格式整理。
+    /// </summary>
+    [EmailAddress(ErrorMessage = "Email 格式不正確，請重新輸入。")]
+    [StringLength(100, ErrorMessage = "Email 長度不得超過 100 個字元。")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// 消息來源，例如廣告、朋友介紹等。
+    /// </summary>
+    [StringLength(100, ErrorMessage = "消息來源長度不得超過 100 個字元。")]
+    public string? Source { get; set; }
+
+    /// <summary>
+    /// 為何選擇本服務的原因或需求描述。
+    /// </summary>
+    [StringLength(255, ErrorMessage = "為何選擇長度不得超過 255 個字元。")]
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// 其他備註資訊。
+    /// </summary>
+    [StringLength(255, ErrorMessage = "備註長度不得超過 255 個字元。")]
+    public string? Remark { get; set; }
+}

--- a/src/DentstageToolApp.Api/Customers/CreateCustomerResponse.cs
+++ b/src/DentstageToolApp.Api/Customers/CreateCustomerResponse.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace DentstageToolApp.Api.Customers;
+
+/// <summary>
+/// 新增客戶成功後回傳給前端的結果資訊。
+/// </summary>
+public class CreateCustomerResponse
+{
+    /// <summary>
+    /// 客戶主鍵識別碼，供後續查詢或編輯使用。
+    /// </summary>
+    public string CustomerUid { get; set; } = null!;
+
+    /// <summary>
+    /// 客戶名稱。
+    /// </summary>
+    public string CustomerName { get; set; } = null!;
+
+    /// <summary>
+    /// 聯絡電話。
+    /// </summary>
+    public string? Phone { get; set; }
+
+    /// <summary>
+    /// 客戶類別。
+    /// </summary>
+    public string? Category { get; set; }
+
+    /// <summary>
+    /// 客戶性別。
+    /// </summary>
+    public string? Gender { get; set; }
+
+    /// <summary>
+    /// 所在縣市。
+    /// </summary>
+    public string? County { get; set; }
+
+    /// <summary>
+    /// 所在區域或鄉鎮。
+    /// </summary>
+    public string? Township { get; set; }
+
+    /// <summary>
+    /// 電子郵件。
+    /// </summary>
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// 消息來源。
+    /// </summary>
+    public string? Source { get; set; }
+
+    /// <summary>
+    /// 為何選擇本服務的原因或需求描述。
+    /// </summary>
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// 其他備註資訊。
+    /// </summary>
+    public string? Remark { get; set; }
+
+    /// <summary>
+    /// 建立時間，以 UTC 紀錄。
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// 操作完成提示訊息，方便前端直接顯示。
+    /// </summary>
+    public string Message { get; set; } = null!;
+}

--- a/src/DentstageToolApp.Api/Program.cs
+++ b/src/DentstageToolApp.Api/Program.cs
@@ -10,6 +10,7 @@ using DentstageToolApp.Api.Services.BrandModels;
 using DentstageToolApp.Api.Services.Car;
 using DentstageToolApp.Api.Services.CarPlate;
 using DentstageToolApp.Api.Services.Quotation;
+using DentstageToolApp.Api.Services.Customer;
 using DentstageToolApp.Infrastructure.Data;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
@@ -143,6 +144,7 @@ builder.Services.AddScoped<IQuotationService, QuotationService>();
 builder.Services.AddScoped<ICarPlateRecognitionService, CarPlateRecognitionService>();
 builder.Services.AddScoped<ICarManagementService, CarManagementService>();
 builder.Services.AddScoped<IBrandModelQueryService, BrandModelQueryService>();
+builder.Services.AddScoped<ICustomerManagementService, CustomerManagementService>();
 builder.Services.AddHostedService<RefreshTokenCleanupService>();
 
 var app = builder.Build();

--- a/src/DentstageToolApp.Api/Services/Customer/CustomerManagementException.cs
+++ b/src/DentstageToolApp.Api/Services/Customer/CustomerManagementException.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Net;
+
+namespace DentstageToolApp.Api.Services.Customer;
+
+/// <summary>
+/// 客戶維運相關操作失敗時所拋出的自訂例外，方便轉換對應的 HTTP 狀態碼。
+/// </summary>
+public class CustomerManagementException : Exception
+{
+    /// <summary>
+    /// 對應的 HTTP 狀態碼。
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// 建立例外並指派狀態碼與訊息。
+    /// </summary>
+    public CustomerManagementException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}

--- a/src/DentstageToolApp.Api/Services/Customer/CustomerManagementService.cs
+++ b/src/DentstageToolApp.Api/Services/Customer/CustomerManagementService.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Customers;
+using DentstageToolApp.Infrastructure.Data;
+using DentstageToolApp.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Services.Customer;
+
+/// <summary>
+/// 客戶維運服務實作，負責處理新增客戶的資料整理、檢核與儲存流程。
+/// </summary>
+public class CustomerManagementService : ICustomerManagementService
+{
+    private readonly DentstageToolAppContext _dbContext;
+    private readonly ILogger<CustomerManagementService> _logger;
+
+    /// <summary>
+    /// 建構子，注入資料庫內容物件與記錄器。
+    /// </summary>
+    public CustomerManagementService(DentstageToolAppContext dbContext, ILogger<CustomerManagementService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<CreateCustomerResponse> CreateCustomerAsync(CreateCustomerRequest request, string operatorName, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            throw new CustomerManagementException(HttpStatusCode.BadRequest, "請提供客戶建立資料。");
+        }
+
+        // ---------- 參數整理區 ----------
+        var customerName = NormalizeRequiredText(request.CustomerName, "客戶名稱");
+        var operatorLabel = NormalizeOperator(operatorName);
+        var customerType = NormalizeOptionalText(request.Category);
+        var gender = NormalizeOptionalText(request.Gender);
+        var county = NormalizeOptionalText(request.County);
+        var township = NormalizeOptionalText(request.Township);
+        var email = NormalizeEmail(request.Email);
+        var source = NormalizeOptionalText(request.Source);
+        var reason = NormalizeOptionalText(request.Reason);
+        var remark = NormalizeOptionalText(request.Remark);
+        var phone = NormalizeOptionalText(request.Phone);
+        var phoneQuery = NormalizePhoneQuery(phone);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // ---------- 資料檢核區 ----------
+        if (!string.IsNullOrEmpty(phoneQuery))
+        {
+            var duplicate = await _dbContext.Customers
+                .AsNoTracking()
+                .AnyAsync(customer =>
+                    customer.PhoneQuery == phoneQuery
+                    || customer.Phone == phone,
+                    cancellationToken);
+
+            if (duplicate)
+            {
+                throw new CustomerManagementException(HttpStatusCode.Conflict, "該聯絡電話已存在客戶資料，請勿重複新增。");
+            }
+        }
+
+        // ---------- 實體建立區 ----------
+        var now = DateTime.UtcNow;
+        var customerEntity = new Customer
+        {
+            CustomerUid = BuildCustomerUid(),
+            Name = customerName,
+            CustomerType = customerType,
+            Gender = gender,
+            Phone = phone,
+            PhoneQuery = phoneQuery,
+            Email = email,
+            County = county,
+            Township = township,
+            Source = source,
+            Reason = reason,
+            ConnectRemark = remark,
+            CreationTimestamp = now,
+            CreatedBy = operatorLabel,
+            ModificationTimestamp = now,
+            ModifiedBy = operatorLabel
+        };
+
+        await _dbContext.Customers.AddAsync(customerEntity, cancellationToken);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("操作人員 {Operator} 新增客戶 {CustomerUid} ({CustomerName}) 成功。", operatorLabel, customerEntity.CustomerUid, customerEntity.Name);
+
+        // ---------- 組裝回應區 ----------
+        return new CreateCustomerResponse
+        {
+            CustomerUid = customerEntity.CustomerUid,
+            CustomerName = customerEntity.Name ?? customerName,
+            Phone = customerEntity.Phone,
+            Category = customerEntity.CustomerType,
+            Gender = customerEntity.Gender,
+            County = customerEntity.County,
+            Township = customerEntity.Township,
+            Email = customerEntity.Email,
+            Source = customerEntity.Source,
+            Reason = customerEntity.Reason,
+            Remark = customerEntity.ConnectRemark,
+            CreatedAt = now,
+            Message = "已建立客戶資料。"
+        };
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 產生符合規範的客戶主鍵，使用 Cu_ 前綴搭配 GUID。
+    /// </summary>
+    private static string BuildCustomerUid()
+    {
+        return $"Cu_{Guid.NewGuid().ToString().ToUpperInvariant()}";
+    }
+
+    /// <summary>
+    /// 處理必填文字欄位，若為空值則拋出例外提示呼叫端補齊。
+    /// </summary>
+    private static string NormalizeRequiredText(string? value, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new CustomerManagementException(HttpStatusCode.BadRequest, $"{fieldName}為必填欄位，請重新輸入。");
+        }
+
+        return value.Trim();
+    }
+
+    /// <summary>
+    /// 處理可選文字欄位，若為空白則回傳 null，避免寫入多餘空白。
+    /// </summary>
+    private static string? NormalizeOptionalText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+
+    /// <summary>
+    /// 將 Email 轉成統一格式，包含移除空白並轉為小寫。
+    /// </summary>
+    private static string? NormalizeEmail(string? email)
+    {
+        var normalized = NormalizeOptionalText(email);
+        return normalized?.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// 將電話欄位轉成僅包含數字的查詢字串，方便後續比對。
+    /// </summary>
+    private static string? NormalizePhoneQuery(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone))
+        {
+            return null;
+        }
+
+        var digits = new string(phone.Where(char.IsDigit).ToArray());
+        return string.IsNullOrWhiteSpace(digits) ? null : digits;
+    }
+
+    /// <summary>
+    /// 將傳入的操作人員名稱正規化，避免寫入空白或 null。
+    /// </summary>
+    private static string NormalizeOperator(string? operatorName)
+    {
+        if (string.IsNullOrWhiteSpace(operatorName))
+        {
+            return "UnknownUser";
+        }
+
+        return operatorName.Trim();
+    }
+
+    // ---------- 生命週期 ----------
+    // 服務為短期生命週期，由 DI 框架管理，無需額外生命週期邏輯。
+}

--- a/src/DentstageToolApp.Api/Services/Customer/ICustomerManagementService.cs
+++ b/src/DentstageToolApp.Api/Services/Customer/ICustomerManagementService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Customers;
+
+namespace DentstageToolApp.Api.Services.Customer;
+
+/// <summary>
+/// 客戶維運服務介面，定義新增客戶所需的操作。
+/// </summary>
+public interface ICustomerManagementService
+{
+    /// <summary>
+    /// 建立新的客戶資料。
+    /// </summary>
+    /// <param name="request">客戶建立請求內容。</param>
+    /// <param name="operatorName">操作人員名稱。</param>
+    /// <param name="cancellationToken">取消權杖。</param>
+    /// <returns>回傳建立完成的客戶資訊。</returns>
+    Task<CreateCustomerResponse> CreateCustomerAsync(CreateCustomerRequest request, string operatorName, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## 摘要
- 建立新增客戶請求與回應模型，補上欄位驗證規則
- 新增客戶維運服務與自訂例外，處理電話重複檢核與資料整理
- 新增 CustomersController 暴露 POST /api/customers 並於啟動時註冊相關服務

## 測試
- ⚠️ `dotnet build`（環境缺少 dotnet 指令）

------
https://chatgpt.com/codex/tasks/task_e_68dcdb2f9cc483249ee41ee503e9dfca