### PR TITLE
新增技師名單查詢 API

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/TechniciansController.cs
+++ b/src/DentstageToolApp.Api/Controllers/TechniciansController.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Technicians;
+using DentstageToolApp.Api.Services.Technician;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Controllers;
+
+/// <summary>
+/// 技師資料查詢 API，提供前端取得特定店家的技師名單。
+/// </summary>
+[ApiController]
+[Route("api/technicians")]
+[Authorize]
+public class TechniciansController : ControllerBase
+{
+    private readonly ITechnicianQueryService _technicianQueryService;
+    private readonly ILogger<TechniciansController> _logger;
+
+    /// <summary>
+    /// 建構子，注入技師查詢服務與記錄器。
+    /// </summary>
+    public TechniciansController(
+        ITechnicianQueryService technicianQueryService,
+        ILogger<TechniciansController> logger)
+    {
+        _technicianQueryService = technicianQueryService;
+        _logger = logger;
+    }
+
+    // ---------- API 呼叫區 ----------
+
+    /// <summary>
+    /// 取得指定店家的技師名單，供前端建立下拉選單使用。
+    /// </summary>
+    /// <param name="query">查詢參數，需包含店家識別碼。</param>
+    /// <param name="cancellationToken">取消權杖，供前端取消請求。</param>
+    [HttpGet]
+    [ProducesResponseType(typeof(TechnicianListResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<TechnicianListResponse>> GetTechniciansAsync([FromQuery] TechnicianListQuery query, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            // 若查詢參數未符合驗證條件，直接回傳標準 ProblemDetails 供前端顯示。
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            _logger.LogDebug("查詢店家 {StoreId} 的技師名單。", query.StoreId);
+            var response = await _technicianQueryService.GetTechniciansAsync(query, cancellationToken);
+            return Ok(response);
+        }
+        catch (TechnicianQueryServiceException ex)
+        {
+            // 已知的服務例外轉換為 ProblemDetails，保留原始狀態碼與訊息。
+            _logger.LogWarning(ex, "查詢技師名單失敗：{Message}", ex.Message);
+            return BuildProblemDetails(ex.StatusCode, ex.Message, "查詢技師名單失敗");
+        }
+        catch (OperationCanceledException)
+        {
+            // 前端若取消請求，統一回應 499 狀態碼資訊，讓前端得知流程被中止。
+            _logger.LogInformation("查詢技師名單流程被取消。");
+            return BuildProblemDetails((HttpStatusCode)499, "請求已取消，資料未更新。", "查詢技師名單已取消");
+        }
+        catch (Exception ex)
+        {
+            // 其他未預期錯誤以 500 形式告知前端稍後再試。
+            _logger.LogError(ex, "查詢技師名單流程發生未預期錯誤。");
+            return BuildProblemDetails(HttpStatusCode.InternalServerError, "系統處理請求時發生錯誤，請稍後再試。", "查詢技師名單失敗");
+        }
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 將錯誤訊息組裝為 ProblemDetails，統一錯誤回應格式。
+    /// </summary>
+    private ActionResult BuildProblemDetails(HttpStatusCode statusCode, string message, string title)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = (int)statusCode,
+            Title = title,
+            Detail = message,
+            Instance = HttpContext.Request.Path
+        };
+
+        return StatusCode(problem.Status ?? StatusCodes.Status500InternalServerError, problem);
+    }
+
+    // ---------- 生命週期 ----------
+    // 控制器目前沒有額外生命週期事件，保留區塊以符合專案規範。
+}

--- a/src/DentstageToolApp.Api/Program.cs
+++ b/src/DentstageToolApp.Api/Program.cs
@@ -10,6 +10,7 @@ using DentstageToolApp.Api.Services.BrandModels;
 using DentstageToolApp.Api.Services.Car;
 using DentstageToolApp.Api.Services.CarPlate;
 using DentstageToolApp.Api.Services.Quotation;
+using DentstageToolApp.Api.Services.Technician;
 using DentstageToolApp.Api.Services.Customer;
 using DentstageToolApp.Infrastructure.Data;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -146,6 +147,7 @@ builder.Services.AddScoped<ICarManagementService, CarManagementService>();
 builder.Services.AddScoped<IBrandModelQueryService, BrandModelQueryService>();
 builder.Services.AddScoped<ICustomerManagementService, CustomerManagementService>();
 builder.Services.AddScoped<ICustomerLookupService, CustomerLookupService>();
+builder.Services.AddScoped<ITechnicianQueryService, TechnicianQueryService>();
 builder.Services.AddHostedService<RefreshTokenCleanupService>();
 
 var app = builder.Build();

--- a/src/DentstageToolApp.Api/Services/Technician/ITechnicianQueryService.cs
+++ b/src/DentstageToolApp.Api/Services/Technician/ITechnicianQueryService.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Technicians;
+
+namespace DentstageToolApp.Api.Services.Technician;
+
+/// <summary>
+/// 技師資料查詢服務介面，負責提供店家技師名單。
+/// </summary>
+public interface ITechnicianQueryService
+{
+    /// <summary>
+    /// 依據查詢條件取得技師名單資料。
+    /// </summary>
+    /// <param name="query">查詢參數，包含店家識別碼。</param>
+    /// <param name="cancellationToken">取消權杖，供前端中止操作。</param>
+    /// <returns>回傳整理後的技師名單。</returns>
+    Task<TechnicianListResponse> GetTechniciansAsync(TechnicianListQuery query, CancellationToken cancellationToken);
+}

--- a/src/DentstageToolApp.Api/Services/Technician/TechnicianQueryService.cs
+++ b/src/DentstageToolApp.Api/Services/Technician/TechnicianQueryService.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Technicians;
+using DentstageToolApp.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Services.Technician;
+
+/// <summary>
+/// 技師資料查詢服務實作，負責從資料庫取得特定店家的技師名單。
+/// </summary>
+public class TechnicianQueryService : ITechnicianQueryService
+{
+    private readonly DentstageToolAppContext _dbContext;
+    private readonly ILogger<TechnicianQueryService> _logger;
+
+    /// <summary>
+    /// 建構子，注入資料庫內容物件與記錄器。
+    /// </summary>
+    public TechnicianQueryService(DentstageToolAppContext dbContext, ILogger<TechnicianQueryService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TechnicianListResponse> GetTechniciansAsync(TechnicianListQuery query, CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (query is null)
+            {
+                // 控制器理論上會先處理空值，仍保留檢查避免被其他呼叫端誤用。
+                throw new TechnicianQueryServiceException(HttpStatusCode.BadRequest, "查詢參數不可為空。");
+            }
+
+            if (query.StoreId <= 0)
+            {
+                // 若店家識別碼小於等於零，代表格式錯誤，直接拋出可預期例外。
+                throw new TechnicianQueryServiceException(HttpStatusCode.BadRequest, "請提供有效的店家識別碼。");
+            }
+
+            // ---------- 查詢組合區 ----------
+            // 透過技師主檔資料表過濾店家識別碼，並僅保留必要欄位，降低資料傳輸量。
+            var technicians = await _dbContext.Technicians
+                .AsNoTracking()
+                .Where(technician => technician.StoreId == query.StoreId)
+                .Select(technician => new TechnicianItem
+                {
+                    TechnicianId = technician.TechnicianId,
+                    TechnicianName = technician.TechnicianName
+                })
+                .OrderBy(technician => technician.TechnicianName, StringComparer.CurrentCulture)
+                .ToListAsync(cancellationToken);
+
+            // ---------- 組裝回應區 ----------
+            // 即便沒有資料也回傳空集合，讓前端可以顯示相對應提示。
+            return new TechnicianListResponse
+            {
+                Items = technicians
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            // 前端若在等待過程中取消查詢，統一轉換為 499 狀態碼，方便控制器處理。
+            _logger.LogInformation("技師名單查詢流程被取消。");
+            throw new TechnicianQueryServiceException((HttpStatusCode)499, "查詢已取消，請重新嘗試。");
+        }
+        catch (TechnicianQueryServiceException)
+        {
+            // 已知的業務例外直接往外拋出，讓控制器維持相同訊息與狀態碼。
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // 其他未預期的錯誤記錄詳細資訊並轉換為通用錯誤訊息。
+            _logger.LogError(ex, "查詢技師名單時發生未預期錯誤。");
+            throw new TechnicianQueryServiceException(HttpStatusCode.InternalServerError, "查詢技師名單發生錯誤，請稍後再試。");
+        }
+    }
+}
+
+/// <summary>
+/// 技師查詢專用例外類別，封裝 HTTP 狀態碼便於控制器使用。
+/// </summary>
+public class TechnicianQueryServiceException : Exception
+{
+    /// <summary>
+    /// 建構子，建立包含狀態碼與訊息的例外物件。
+    /// </summary>
+    public TechnicianQueryServiceException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>
+    /// 對應的 HTTP 狀態碼，供控制器轉換為 ProblemDetails。
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+}

--- a/src/DentstageToolApp.Api/Technicians/TechnicianListQuery.cs
+++ b/src/DentstageToolApp.Api/Technicians/TechnicianListQuery.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Technicians;
+
+/// <summary>
+/// 技師名單查詢參數，提供前端傳遞店家識別碼。
+/// </summary>
+public class TechnicianListQuery
+{
+    /// <summary>
+    /// 店家識別碼，僅接受正整數，代表欲查詢的門市。
+    /// </summary>
+    [Required(ErrorMessage = "請提供店家識別碼。")]
+    [Range(1, int.MaxValue, ErrorMessage = "店家識別碼格式不正確。")]
+    public int StoreId { get; set; }
+}

--- a/src/DentstageToolApp.Api/Technicians/TechnicianListResponse.cs
+++ b/src/DentstageToolApp.Api/Technicians/TechnicianListResponse.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace DentstageToolApp.Api.Technicians;
+
+/// <summary>
+/// 技師名單回應物件，提供前端建立下拉選單或列表使用。
+/// </summary>
+public class TechnicianListResponse
+{
+    /// <summary>
+    /// 技師清單集合，依照名稱排序後回傳。
+    /// </summary>
+    public List<TechnicianItem> Items { get; set; } = new();
+}
+
+/// <summary>
+/// 技師資訊資料列，包含識別碼與名稱。
+/// </summary>
+public class TechnicianItem
+{
+    /// <summary>
+    /// 技師識別碼，對應後端技師主鍵。
+    /// </summary>
+    public int TechnicianId { get; set; }
+
+    /// <summary>
+    /// 技師姓名，提供前端顯示。
+    /// </summary>
+    public string TechnicianName { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## 摘要
- 新增技師名單控制器與查詢參數、回應模型，提供前端依店家取得技師清單
- 建立技師查詢服務與自訂例外，並註冊至 DI 容器

## 測試
- 未執行（依需求允許略過）

------
https://chatgpt.com/codex/tasks/task_e_68dcdf8d724c8324a8f807424b12e71c