### PR TITLE
新增估價單建檔與查詢編輯 API

### DIFF
--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -1,0 +1,165 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 建立估價單時前端需提供的欄位集合，涵蓋店家、車輛、客戶與估價資訊。
+/// </summary>
+public class CreateQuotationRequest
+{
+    /// <summary>
+    /// 店家相關資訊。
+    /// </summary>
+    [Required]
+    public QuotationStoreInfo Store { get; set; } = new();
+
+    /// <summary>
+    /// 車輛相關資訊。
+    /// </summary>
+    [Required]
+    public QuotationCarInfo Car { get; set; } = new();
+
+    /// <summary>
+    /// 客戶相關資訊。
+    /// </summary>
+    [Required]
+    public QuotationCustomerInfo Customer { get; set; } = new();
+
+    /// <summary>
+    /// 服務類別的明細資訊。
+    /// </summary>
+    public QuotationServiceCategoryCollection? ServiceCategories { get; set; }
+
+    /// <summary>
+    /// 各類別金額總覽。
+    /// </summary>
+    public QuotationCategoryTotal? CategoryTotal { get; set; }
+
+    /// <summary>
+    /// 車體確認單資料。
+    /// </summary>
+    public QuotationCarBodyConfirmation? CarBodyConfirmation { get; set; }
+
+    /// <summary>
+    /// 估價單整體備註，會以 JSON 包裝儲存在資料庫中。
+    /// </summary>
+    public string? Remark { get; set; }
+}
+
+/// <summary>
+/// 估價單店家資訊欄位。
+/// </summary>
+public class QuotationStoreInfo
+{
+    /// <summary>
+    /// 門市識別碼，若有對應主檔可一併傳入。
+    /// </summary>
+    public int? StoreId { get; set; }
+
+    /// <summary>
+    /// 門市唯一代碼，可對應舊系統欄位。
+    /// </summary>
+    public string? StoreUid { get; set; }
+
+    /// <summary>
+    /// 店鋪名稱。
+    /// </summary>
+    [Required]
+    public string? StoreName { get; set; }
+
+    /// <summary>
+    /// 估價技師。
+    /// </summary>
+    public string? EstimatorName { get; set; }
+
+    /// <summary>
+    /// 製單技師。
+    /// </summary>
+    public string? CreatorName { get; set; }
+
+    /// <summary>
+    /// 建立日期。
+    /// </summary>
+    public DateTime? CreatedDate { get; set; }
+
+    /// <summary>
+    /// 預約日期。
+    /// </summary>
+    public DateTime? ReservationDate { get; set; }
+
+    /// <summary>
+    /// 維修來源。
+    /// </summary>
+    public string? Source { get; set; }
+
+    /// <summary>
+    /// 預計維修日期。
+    /// </summary>
+    public DateTime? RepairDate { get; set; }
+}
+
+/// <summary>
+/// 車輛相關資料欄位。
+/// </summary>
+public class QuotationCarInfo
+{
+    /// <summary>
+    /// 車牌號碼。
+    /// </summary>
+    [Required]
+    public string? LicensePlate { get; set; }
+
+    /// <summary>
+    /// 車款或品牌名稱。
+    /// </summary>
+    public string? Brand { get; set; }
+
+    /// <summary>
+    /// 車型名稱。
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// 車色。
+    /// </summary>
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// 車輛備註。
+    /// </summary>
+    public string? Remark { get; set; }
+}
+
+/// <summary>
+/// 客戶相關資料欄位。
+/// </summary>
+public class QuotationCustomerInfo
+{
+    /// <summary>
+    /// 客戶名稱。
+    /// </summary>
+    [Required]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// 聯絡電話。
+    /// </summary>
+    public string? Phone { get; set; }
+
+    /// <summary>
+    /// 性別。
+    /// </summary>
+    public string? Gender { get; set; }
+
+    /// <summary>
+    /// 消息來源。
+    /// </summary>
+    public string? Source { get; set; }
+
+    /// <summary>
+    /// 客戶備註。
+    /// </summary>
+    public string? Remark { get; set; }
+}
+

--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationResponse.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationResponse.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 建立估價單後回傳的欄位，提供前端後續導向或提示使用。
+/// </summary>
+public class CreateQuotationResponse
+{
+    /// <summary>
+    /// 系統產生的估價單唯一識別碼。
+    /// </summary>
+    public string QuotationUid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 系統產生的估價單編號。
+    /// </summary>
+    public string? QuotationNo { get; set; }
+
+    /// <summary>
+    /// 建立時間，使用 UTC 儲存方便日後轉換時區。
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// 建立結果訊息，提供前端顯示成功提示。
+    /// </summary>
+    public string Message { get; set; } = "已建立估價單。";
+}
+

--- a/src/DentstageToolApp.Api/Quotations/GetQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/GetQuotationRequest.cs
@@ -1,0 +1,18 @@
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 取得估價單詳細資料時使用的請求格式，支援以 UID 或編號查詢。
+/// </summary>
+public class GetQuotationRequest
+{
+    /// <summary>
+    /// 估價單唯一識別碼，優先使用。
+    /// </summary>
+    public string? QuotationUid { get; set; }
+
+    /// <summary>
+    /// 估價單編號，若未提供 UID 可改以編號查詢。
+    /// </summary>
+    public string? QuotationNo { get; set; }
+}
+

--- a/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 估價單的服務分類資料集合，依凹痕、鈑烤與其他三大類別呈現。
+/// </summary>
+public class QuotationServiceCategoryCollection
+{
+    /// <summary>
+    /// 凹痕服務的綜合資訊、傷痕項目與金額。
+    /// </summary>
+    public QuotationCategoryBlock? Dent { get; set; }
+
+    /// <summary>
+    /// 鈑烤服務的綜合資訊、傷痕項目與金額。
+    /// </summary>
+    public QuotationCategoryBlock? Paint { get; set; }
+
+    /// <summary>
+    /// 其他服務的綜合資訊、傷痕項目與金額。
+    /// </summary>
+    public QuotationCategoryBlock? Other { get; set; }
+}
+
+/// <summary>
+/// 每個服務類別的資料區塊，整合整體資訊、傷痕清單與金額摘要。
+/// </summary>
+public class QuotationCategoryBlock
+{
+    /// <summary>
+    /// 類別整體資訊，例如漆況、是否留車等。
+    /// </summary>
+    [Required]
+    public QuotationCategoryOverallInfo Overall { get; set; } = new();
+
+    /// <summary>
+    /// 傷痕細項列表，紀錄各位置的照片與估價金額。
+    /// </summary>
+    public List<QuotationDamageItem> Damages { get; set; } = new();
+
+    /// <summary>
+    /// 類別金額資訊，包含傷痕小計與折扣。
+    /// </summary>
+    [Required]
+    public QuotationCategoryAmount Amount { get; set; } = new();
+}
+
+/// <summary>
+/// 類別整體資訊欄位，說明車輛狀況與施工評估。
+/// </summary>
+public class QuotationCategoryOverallInfo
+{
+    /// <summary>
+    /// 漆況說明，例如是否有鍍膜或烤漆紀錄。
+    /// </summary>
+    public string? PaintCondition { get; set; }
+
+    /// <summary>
+    /// 工具評估描述，可用來紀錄特殊注意事項。
+    /// </summary>
+    public string? ToolEvaluation { get; set; }
+
+    /// <summary>
+    /// 是否需要留車施工。
+    /// </summary>
+    public bool? NeedStay { get; set; }
+
+    /// <summary>
+    /// 類別備註，補充估價技師的說明。
+    /// </summary>
+    public string? Remark { get; set; }
+
+    /// <summary>
+    /// 預估維修時間描述，可自訂格式（例如 3 小時或 2~3 天）。
+    /// </summary>
+    public string? EstimatedRepairTime { get; set; }
+
+    /// <summary>
+    /// 預估修復程度，例如 9 成新或仍留痕跡。
+    /// </summary>
+    public string? EstimatedRestorationLevel { get; set; }
+
+    /// <summary>
+    /// 是否評估可維修，false 代表建議改走其他處理方式。
+    /// </summary>
+    public bool? IsRepairable { get; set; }
+}
+
+/// <summary>
+/// 單一傷痕的估價資料，包含照片與金額。
+/// </summary>
+public class QuotationDamageItem
+{
+    /// <summary>
+    /// 傷痕照片的檔案識別，通常為檔名或外部儲存的 URL。
+    /// </summary>
+    public string? Photo { get; set; }
+
+    /// <summary>
+    /// 傷痕所在位置描述，例如左前門或後保桿。
+    /// </summary>
+    public string? Position { get; set; }
+
+    /// <summary>
+    /// 凹痕狀況或受損程度描述。
+    /// </summary>
+    public string? DentStatus { get; set; }
+
+    /// <summary>
+    /// 備註或補充說明，可記錄施工方式。
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// 該傷痕預估的施工金額。
+    /// </summary>
+    public decimal? EstimatedAmount { get; set; }
+}
+
+/// <summary>
+/// 類別金額資訊，包含傷痕金額小計、其他費用與折扣。
+/// </summary>
+public class QuotationCategoryAmount
+{
+    /// <summary>
+    /// 傷痕預估金額的小計。
+    /// </summary>
+    public decimal? DamageSubtotal { get; set; }
+
+    /// <summary>
+    /// 類別其他費用，例如耗材費或代步車。
+    /// </summary>
+    public decimal? AdditionalFee { get; set; }
+
+    /// <summary>
+    /// 折扣趴數，單位為百分比。
+    /// </summary>
+    public decimal? DiscountPercentage { get; set; }
+
+    /// <summary>
+    /// 折扣原因說明，方便稽核。
+    /// </summary>
+    public string? DiscountReason { get; set; }
+}
+
+/// <summary>
+/// 全部類別的金額總覽，提供總金額與零頭折扣資訊。
+/// </summary>
+public class QuotationCategoryTotal
+{
+    /// <summary>
+    /// 各類別金額小計列表，鍵值對應類別名稱（例如 dent、paint）。
+    /// </summary>
+    public Dictionary<string, decimal?> CategorySubtotals { get; set; } = new();
+
+    /// <summary>
+    /// 零頭折扣金額。
+    /// </summary>
+    public decimal? RoundingDiscount { get; set; }
+}
+
+/// <summary>
+/// 車體確認單資料，包含標註後的車身圖片與客戶簽名。
+/// </summary>
+public class QuotationCarBodyConfirmation
+{
+    /// <summary>
+    /// 已標註受損位置的車身圖片，可為檔案識別或 URL。
+    /// </summary>
+    public string? AnnotatedImage { get; set; }
+
+    /// <summary>
+    /// 客戶簽名影像資料。
+    /// </summary>
+    public string? Signature { get; set; }
+}
+

--- a/src/DentstageToolApp.Api/Quotations/QuotationDetailResponse.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationDetailResponse.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 估價單詳細資料的輸出格式，包含基本資訊與擴充欄位。
+/// </summary>
+public class QuotationDetailResponse
+{
+    /// <summary>
+    /// 估價單唯一識別碼。
+    /// </summary>
+    public string QuotationUid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 估價單編號。
+    /// </summary>
+    public string? QuotationNo { get; set; }
+
+    /// <summary>
+    /// 估價單狀態。
+    /// </summary>
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// 建立時間。
+    /// </summary>
+    public DateTime? CreatedAt { get; set; }
+
+    /// <summary>
+    /// 最後修改時間。
+    /// </summary>
+    public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// 店家資訊。
+    /// </summary>
+    public QuotationStoreInfo Store { get; set; } = new();
+
+    /// <summary>
+    /// 車輛資訊。
+    /// </summary>
+    public QuotationCarInfo Car { get; set; } = new();
+
+    /// <summary>
+    /// 客戶資訊。
+    /// </summary>
+    public QuotationCustomerInfo Customer { get; set; } = new();
+
+    /// <summary>
+    /// 估價單整體備註。
+    /// </summary>
+    public string? Remark { get; set; }
+
+    /// <summary>
+    /// 服務類別資料。
+    /// </summary>
+    public QuotationServiceCategoryCollection? ServiceCategories { get; set; }
+
+    /// <summary>
+    /// 類別金額總覽。
+    /// </summary>
+    public QuotationCategoryTotal? CategoryTotal { get; set; }
+
+    /// <summary>
+    /// 車體確認單資料。
+    /// </summary>
+    public QuotationCarBodyConfirmation? CarBodyConfirmation { get; set; }
+}
+

--- a/src/DentstageToolApp.Api/Quotations/UpdateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/UpdateQuotationRequest.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 編輯估價單所需的欄位，聚焦車輛、客戶與各類別備註。
+/// </summary>
+public class UpdateQuotationRequest
+{
+    /// <summary>
+    /// 估價單唯一識別碼，優先使用於更新。
+    /// </summary>
+    public string? QuotationUid { get; set; }
+
+    /// <summary>
+    /// 估價單編號，若未提供 UID 可改以編號更新。
+    /// </summary>
+    public string? QuotationNo { get; set; }
+
+    /// <summary>
+    /// 車輛資訊。
+    /// </summary>
+    public QuotationCarInfo Car { get; set; } = new();
+
+    /// <summary>
+    /// 客戶資訊。
+    /// </summary>
+    public QuotationCustomerInfo Customer { get; set; } = new();
+
+    /// <summary>
+    /// 各類別整體備註，key 使用 dent、paint、other。
+    /// </summary>
+    public Dictionary<string, string?> CategoryRemarks { get; set; } = new();
+
+    /// <summary>
+    /// 若需要同步更新估價單整體備註可一併傳入。
+    /// </summary>
+    public string? Remark { get; set; }
+}
+

--- a/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
@@ -1,6 +1,6 @@
+using DentstageToolApp.Api.Quotations;
 using System.Threading;
 using System.Threading.Tasks;
-using DentstageToolApp.Api.Quotations;
 
 namespace DentstageToolApp.Api.Services.Quotation;
 
@@ -16,4 +16,27 @@ public interface IQuotationService
     /// <param name="cancellationToken">取消權杖，供呼叫端取消長時間查詢。</param>
     /// <returns>估價單列表與分頁資訊。</returns>
     Task<QuotationListResponse> GetQuotationsAsync(QuotationListQuery query, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 建立估價單並回傳基本資訊。
+    /// </summary>
+    /// <param name="request">建立所需的欄位資料。</param>
+    /// <param name="operatorName">操作人員名稱，會填入建立與修改者欄位。</param>
+    /// <param name="cancellationToken">取消權杖，支援前端取消請求。</param>
+    Task<CreateQuotationResponse> CreateQuotationAsync(CreateQuotationRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 取得單一估價單的詳細資訊。
+    /// </summary>
+    /// <param name="request">查詢條件，支援以 UID 或編號取得。</param>
+    /// <param name="cancellationToken">取消權杖。</param>
+    Task<QuotationDetailResponse> GetQuotationAsync(GetQuotationRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 更新估價單的車輛、客戶與類別備註資訊。
+    /// </summary>
+    /// <param name="request">更新內容。</param>
+    /// <param name="operatorName">操作人員名稱。</param>
+    /// <param name="cancellationToken">取消權杖。</param>
+    Task UpdateQuotationAsync(UpdateQuotationRequest request, string operatorName, CancellationToken cancellationToken);
 }

--- a/src/DentstageToolApp.Api/Services/Quotation/QuotationManagementException.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/QuotationManagementException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Net;
+
+namespace DentstageToolApp.Api.Services.Quotation;
+
+/// <summary>
+/// 估價單維運相關操作失敗時拋出的自訂例外，方便控制回傳狀態碼。
+/// </summary>
+public class QuotationManagementException : Exception
+{
+    /// <summary>
+    /// 對應的 HTTP 狀態碼。
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// 建立例外並指定狀態碼與錯誤訊息。
+    /// </summary>
+    public QuotationManagementException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}
+


### PR DESCRIPTION
## 摘要
- 建立估價單建立/查詢/更新所需的請求與回應資料模型，納入服務類別、金額與車體確認資訊
- 擴充 IQuotationService 與 QuotationService，實作建立、查詢、編輯估價單流程並以 JSON 封裝額外欄位
- 調整 QuotationsController，新增 create/detail/edit 端點並統一錯誤回應格式

## 測試
- 無（容器缺少 dotnet 指令）

------
https://chatgpt.com/codex/tasks/task_e_68dce1b72d648324a6881cdd03949698