### PR TITLE
修正技師查詢排序設定導致的查詢失敗

### DIFF
--- a/src/DentstageToolApp.Api/Services/Technician/TechnicianQueryService.cs
+++ b/src/DentstageToolApp.Api/Services/Technician/TechnicianQueryService.cs
@@ -56,7 +56,8 @@ public class TechnicianQueryService : ITechnicianQueryService
                     TechnicianId = technician.TechnicianId,
                     TechnicianName = technician.TechnicianName
                 })
-                .OrderBy(technician => technician.TechnicianName, StringComparer.CurrentCulture)
+                // EF Core 無法直接翻譯帶有 Comparer 的排序，改用預設排序以確保查詢可被翻譯。 
+                .OrderBy(technician => technician.TechnicianName)
                 .ToListAsync(cancellationToken);
 
             // ---------- 組裝回應區 ----------


### PR DESCRIPTION
## 摘要
- 移除技師查詢服務中使用 StringComparer 的排序設定，改用 EF Core 可翻譯的預設排序
- 保留中文註解說明調整原因，確保未來維護時能快速理解背景

## 測試
- 未執行（依指示）

------
https://chatgpt.com/codex/tasks/task_e_68dce6a8c0c48324b7a7cdc705b2ff1c