### PR TITLE
新增 Swagger Mock 範例支援

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/AdminAccountsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/AdminAccountsController.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DentstageToolApp.Api.Admin;
 using DentstageToolApp.Api.Services.Admin;
+using DentstageToolApp.Api.Swagger;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,16 @@ public class AdminAccountsController : ControllerBase
     /// 建立新的使用者帳號與對應裝置機碼。
     /// </summary>
     [HttpPost]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "displayName": "陳大明",
+          "role": "StoreManager",
+          "deviceKey": "CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C",
+          "deviceName": "高雄總店平板",
+          "operatorName": "SystemAdmin"
+        }
+        """)]
     [ProducesResponseType(typeof(CreateUserDeviceResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]

--- a/src/DentstageToolApp.Api/Controllers/AuthController.cs
+++ b/src/DentstageToolApp.Api/Controllers/AuthController.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Security.Claims;
 using DentstageToolApp.Api.Auth;
 using DentstageToolApp.Api.Services.Auth;
+using DentstageToolApp.Api.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -39,6 +40,12 @@ public class AuthController : ControllerBase
     /// BFC29A95-885C-CF45-A91C-F0DD3F1DDD7B 加盟店測試 &#10;
     /// </remarks>
     [HttpPost("login")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "deviceKey": "CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C"
+        }
+        """)]
     [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -72,6 +79,13 @@ public class AuthController : ControllerBase
     /// 透過 Refresh Token 換取新的 Access Token。
     /// </summary>
     [HttpPost("token/refresh")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.MockRefreshToken",
+          "deviceKey": "CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C"
+        }
+        """)]
     [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]

--- a/src/DentstageToolApp.Api/Controllers/CarPlateRecognitionController.cs
+++ b/src/DentstageToolApp.Api/Controllers/CarPlateRecognitionController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DentstageToolApp.Api.CarPlates;
 using DentstageToolApp.Api.Services.CarPlate;
+using DentstageToolApp.Api.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -39,6 +40,13 @@ public class CarPlateRecognitionController : ControllerBase
     /// 上傳車牌影像並回傳車牌、車輛資料與維修紀錄。
     /// </summary>
     [HttpPost("recognitions")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "imageBase64": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD..."
+        }
+        """,
+        contentType: "multipart/form-data")]
     [ProducesResponseType(typeof(CarPlateRecognitionResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -117,6 +125,12 @@ public class CarPlateRecognitionController : ControllerBase
     /// <param name="request">包含欲查詢車牌號碼的請求物件。</param>
     /// <param name="cancellationToken">取消權杖。</param>
     [HttpPost("search")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "licensePlateNumber": "AAA-1234"
+        }
+        """)]
     [ProducesResponseType(typeof(CarPlateMaintenanceHistoryResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/DentstageToolApp.Api/Controllers/CarsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/CarsController.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DentstageToolApp.Api.Cars;
 using DentstageToolApp.Api.Services.Car;
+using DentstageToolApp.Api.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -50,6 +51,16 @@ public class CarsController : ControllerBase
     /// 
     /// </remarks>
     [HttpPost]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "carPlateNumber": "AAA-1234",
+          "brandId": 1,
+          "modelId": 2,
+          "color": "白",
+          "remark": "測試建立車輛資料"
+        }
+        """)]
     [ProducesResponseType(typeof(CreateCarResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]

--- a/src/DentstageToolApp.Api/Controllers/CustomersController.cs
+++ b/src/DentstageToolApp.Api/Controllers/CustomersController.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DentstageToolApp.Api.Customers;
 using DentstageToolApp.Api.Services.Customer;
+using DentstageToolApp.Api.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -47,6 +48,21 @@ public class CustomersController : ControllerBase
     /// {"phone": "0988963537"}
     /// </remarks>
     [HttpPost]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "customerName": "林小華",
+          "phone": "0988123456",
+          "category": "一般客戶",
+          "gender": "Male",
+          "county": "高雄市",
+          "township": "左營區",
+          "email": "demo@dentstage.com",
+          "source": "Facebook",
+          "reason": "想了解凹痕修復方案",
+          "remark": "首次到店，請協助安排體驗"
+        }
+        """)]
     [ProducesResponseType(typeof(CreateCustomerResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
@@ -90,6 +106,12 @@ public class CustomersController : ControllerBase
     /// {"phone": "0988963537"}
     /// </remarks>
     [HttpPost("phone-search")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "phone": "0988123456"
+        }
+        """)]
     [ProducesResponseType(typeof(CustomerPhoneSearchResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<CustomerPhoneSearchResponse>> SearchCustomerByPhoneAsync([FromBody] CustomerPhoneSearchRequest? request, CancellationToken cancellationToken)

--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -1,5 +1,6 @@
 using DentstageToolApp.Api.Quotations;
 using DentstageToolApp.Api.Services.Quotation;
+using DentstageToolApp.Api.Swagger;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -57,6 +58,19 @@ public class QuotationsController : ControllerBase
     /// <param name="request">查詢參數，與 GET 版本相同但由 Body 傳遞。</param>
     /// <param name="cancellationToken">取消權杖，供前端於離開頁面時停止查詢。</param>
     [HttpPost]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "fixType": "DentRepair",
+          "status": "110",
+          "startDate": "2024-03-01T00:00:00",
+          "endDate": "2024-03-31T23:59:59",
+          "customerKeyword": "林",
+          "carPlateKeyword": "AAA",
+          "page": 1,
+          "pageSize": 20
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationListResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<QuotationListResponse>> SearchQuotationsAsync([FromBody] QuotationListQuery request, CancellationToken cancellationToken)
     {
@@ -74,6 +88,75 @@ public class QuotationsController : ControllerBase
     /// 新增估價單，並回傳建立結果與編號資訊。
     /// </summary>
     [HttpPost("create")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "store": {
+            "storeId": 1,
+            "storeUid": "KH001",
+            "storeName": "高雄旗艦店",
+            "estimatorName": "張技師",
+            "creatorName": "王主管",
+            "createdDate": "2024-03-01T10:00:00",
+            "reservationDate": "2024-03-05T15:00:00",
+            "source": "官方網站",
+            "repairDate": "2024-03-08T09:00:00"
+          },
+          "car": {
+            "licensePlate": "AAA-1234",
+            "brand": "Toyota",
+            "model": "Altis",
+            "color": "銀",
+            "remark": "前保桿有刮傷"
+          },
+          "customer": {
+            "name": "林小華",
+            "phone": "0988123456",
+            "gender": "Male",
+            "source": "Facebook",
+            "remark": "首次諮詢"
+          },
+          "serviceCategories": {
+            "dent": {
+              "overall": {
+                "paintCondition": "原廠烤漆",
+                "toolEvaluation": "需特殊拉拔工具",
+                "needStay": true,
+                "remark": "建議留車一天",
+                "estimatedRepairTime": "1 天",
+                "estimatedRestorationLevel": "9 成新",
+                "isRepairable": true
+              },
+              "damages": [
+                {
+                  "photo": "dent-front-door.jpg",
+                  "position": "右前門",
+                  "dentStatus": "中度凹陷",
+                  "description": "需板金搭配烤漆",
+                  "estimatedAmount": 4500
+                }
+              ],
+              "amount": {
+                "damageSubtotal": 4500,
+                "additionalFee": 500,
+                "discountPercentage": 10,
+                "discountReason": "春季活動"
+              }
+            }
+          },
+          "categoryTotal": {
+            "categorySubtotals": {
+              "dent": 5000
+            },
+            "roundingDiscount": 0
+          },
+          "carBodyConfirmation": {
+            "annotatedImage": "https://cdn.dentstage.com/annotated/car-001.png",
+            "signature": "https://cdn.dentstage.com/signature/customer-001.png"
+          },
+          "remark": "請於修復後通知客戶取車"
+        }
+        """)]
     [ProducesResponseType(typeof(CreateQuotationResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
@@ -106,6 +189,12 @@ public class QuotationsController : ControllerBase
     /// 取得單一估價單的詳細資料。
     /// </summary>
     [HttpPost("detail")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationUid": "QTN-20240301-0001"
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationDetailResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -137,6 +226,31 @@ public class QuotationsController : ControllerBase
     /// 編輯估價單資料，更新車輛、客戶與類別備註。
     /// </summary>
     [HttpPost("edit")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationUid": "QTN-20240301-0001",
+          "car": {
+            "licensePlate": "AAA-1234",
+            "brand": "Toyota",
+            "model": "Altis",
+            "color": "銀",
+            "remark": "已更新照片"
+          },
+          "customer": {
+            "name": "林小華",
+            "phone": "0988123456",
+            "gender": "Male",
+            "source": "Facebook",
+            "remark": "同意估價"
+          },
+          "categoryRemarks": {
+            "dent": "追加處理左後門凹痕",
+            "paint": "等待調色"
+          },
+          "remark": "預計 3/8 完成"
+        }
+        """)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/DentstageToolApp.Api/Program.cs
+++ b/src/DentstageToolApp.Api/Program.cs
@@ -12,6 +12,7 @@ using DentstageToolApp.Api.Services.CarPlate;
 using DentstageToolApp.Api.Services.Quotation;
 using DentstageToolApp.Api.Services.Technician;
 using DentstageToolApp.Api.Services.Customer;
+using DentstageToolApp.Api.Swagger;
 using DentstageToolApp.Infrastructure.Data;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
@@ -75,6 +76,9 @@ builder.Services.AddSwaggerGen(options =>
             Array.Empty<string>()
         }
     });
+
+    // 注入 Mock 範例過濾器，將屬性定義的 JSON 直接呈現在 Swagger UI 中
+    options.OperationFilter<MockRequestExampleOperationFilter>();
 });
 // 讀取 Swagger 組態，提供後續中介層調整依據
 var swaggerSection = builder.Configuration.GetSection("Swagger");

--- a/src/DentstageToolApp.Api/Swagger/MockRequestExampleOperationFilter.cs
+++ b/src/DentstageToolApp.Api/Swagger/MockRequestExampleOperationFilter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using DentstageToolApp.Api.Swagger;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace DentstageToolApp.Api.Swagger;
+
+/// <summary>
+/// 讀取 <see cref="SwaggerMockRequestExampleAttribute"/>，將 Mock 範例資料套用到 Swagger Request Body。
+/// </summary>
+public class MockRequestExampleOperationFilter : IOperationFilter
+{
+    /// <summary>
+    /// 將 Attribute 定義的範例寫入 Swagger Operation，提供開發與測試人員直接貼上測試資料。
+    /// </summary>
+    /// <param name="operation">當前操作定義。</param>
+    /// <param name="context">Swagger 產生時的描述內容。</param>
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (operation.RequestBody?.Content is null)
+        {
+            // 沒有 Request Body 的 API 無須處理，直接結束。
+            return;
+        }
+
+        var exampleAttributes = context.MethodInfo
+            .GetCustomAttributes(true)
+            .OfType<SwaggerMockRequestExampleAttribute>()
+            .ToList();
+
+        if (!exampleAttributes.Any())
+        {
+            return;
+        }
+
+        foreach (var attribute in exampleAttributes)
+        {
+            // 確保內容型別存在，若 Swagger 預設未建立則主動補上。
+            if (!operation.RequestBody.Content.TryGetValue(attribute.ContentType, out var mediaType))
+            {
+                mediaType = new OpenApiMediaType();
+                operation.RequestBody.Content[attribute.ContentType] = mediaType;
+            }
+
+            mediaType.Example = BuildExample(attribute.ExampleJson);
+        }
+    }
+
+    /// <summary>
+    /// 依範例字串建立對應的 OpenApi 資料結構，若解析失敗則以字串呈現避免整體失敗。
+    /// </summary>
+    /// <param name="exampleJson">Mock 範例字串。</param>
+    /// <returns>可被 Swagger UI 呈現的 Example。</returns>
+    private static IOpenApiAny BuildExample(string exampleJson)
+    {
+        if (string.IsNullOrWhiteSpace(exampleJson))
+        {
+            return new OpenApiString(string.Empty);
+        }
+
+        try
+        {
+            return OpenApiAnyFactory.CreateFromJson(exampleJson);
+        }
+        catch (Exception)
+        {
+            // 例外時退回純文字，仍能提示開發者範例內容。
+            return new OpenApiString(exampleJson);
+        }
+    }
+}

--- a/src/DentstageToolApp.Api/Swagger/SwaggerMockRequestExampleAttribute.cs
+++ b/src/DentstageToolApp.Api/Swagger/SwaggerMockRequestExampleAttribute.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace DentstageToolApp.Api.Swagger;
+
+/// <summary>
+/// 標註在控制器方法上，為 Swagger Request Body 提供可直接貼上的 Mock 範例資料。
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public sealed class SwaggerMockRequestExampleAttribute : Attribute
+{
+    /// <summary>
+    /// 建立範例屬性，預設使用 JSON 內容型別。
+    /// </summary>
+    /// <param name="exampleJson">符合請求格式的範例字串，建議使用 Raw String 直接撰寫 JSON。</param>
+    /// <param name="contentType">Swagger 要套用的內容型別，預設為 application/json。</param>
+    public SwaggerMockRequestExampleAttribute(string exampleJson, string contentType = "application/json")
+    {
+        ExampleJson = exampleJson;
+        ContentType = contentType;
+    }
+
+    /// <summary>
+    /// Swagger 要顯示的範例 JSON 字串。
+    /// </summary>
+    public string ExampleJson { get; }
+
+    /// <summary>
+    /// 對應的內容型別，預設為 application/json。
+    /// </summary>
+    public string ContentType { get; }
+}


### PR DESCRIPTION
## 摘要
- 建立 SwaggerMockRequestExampleAttribute 與對應的 OperationFilter，讓 Swagger UI 可自動帶入 Mock 測試資料
- 針對車輛、客戶、帳號、身份驗證、車牌辨識與估價單等 API 標註示範輸入內容，方便測試快速驗證

## 測試
- 環境未安裝 dotnet CLI，無法執行建置

------
https://chatgpt.com/codex/tasks/task_e_68dce9e0ef4c832486e4b305b677cd84