### PR TITLE
優化估價單建立自動帶入流程

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -94,6 +94,7 @@ public class QuotationsController : ControllerBase
           "store": {
             "storeId": 1,
             "storeUid": "KH001",
+            "technicianId": 12,
             "storeName": "高雄旗艦店",
             "estimatorName": "張技師",
             "creatorName": "王主管",
@@ -103,6 +104,7 @@ public class QuotationsController : ControllerBase
             "repairDate": "2024-03-08T09:00:00"
           },
           "car": {
+            "carUid": "CAR-20240301-0001",
             "licensePlate": "AAA-1234",
             "brand": "Toyota",
             "model": "Altis",
@@ -110,6 +112,7 @@ public class QuotationsController : ControllerBase
             "remark": "前保桿有刮傷"
           },
           "customer": {
+            "customerUid": "CUST-20240228-0001",
             "name": "林小華",
             "phone": "0988123456",
             "gender": "Male",

--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -63,9 +63,13 @@ public class QuotationStoreInfo
     public string? StoreUid { get; set; }
 
     /// <summary>
-    /// 店鋪名稱。
+    /// 技師識別碼，僅需提供此欄位即可自動帶出所屬門市與技師名稱。
     /// </summary>
-    [Required]
+    public int? TechnicianId { get; set; }
+
+    /// <summary>
+    /// 店鋪名稱，若未提供會依據技師或門市主檔自動補齊。
+    /// </summary>
     public string? StoreName { get; set; }
 
     /// <summary>
@@ -105,9 +109,13 @@ public class QuotationStoreInfo
 public class QuotationCarInfo
 {
     /// <summary>
-    /// 車牌號碼。
+    /// 車輛唯一識別碼，若提供則會自動帶出車牌與車況資訊。
     /// </summary>
-    [Required]
+    public string? CarUid { get; set; }
+
+    /// <summary>
+    /// 車牌號碼，若未提供會依據車輛主檔自動補齊。
+    /// </summary>
     public string? LicensePlate { get; set; }
 
     /// <summary>
@@ -137,9 +145,13 @@ public class QuotationCarInfo
 public class QuotationCustomerInfo
 {
     /// <summary>
-    /// 客戶名稱。
+    /// 客戶唯一識別碼，若提供則會自動帶出客戶聯絡資料。
     /// </summary>
-    [Required]
+    public string? CustomerUid { get; set; }
+
+    /// <summary>
+    /// 客戶名稱，若未提供會依據客戶主檔自動補齊。
+    /// </summary>
     public string? Name { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## 摘要
- 調整估價單建立流程，依據技師識別碼自動帶入門市與技師資訊，並同步綁定車輛、客戶識別碼
- 擴充建立與明細模型欄位，新增 technicianId、carUid、customerUid 等欄位以支援自動補齊
- 更新建立估價單範例請求，示範最小輸入即可完成自動帶入

## 測試
- 無，環境未提供 dotnet 指令

------
https://chatgpt.com/codex/tasks/task_e_68dcef6f5fdc832488bbd044ab65ff68