### PR TITLE
修正車牌欄位命名並解除估價服務命名空間衝突

### DIFF
--- a/src/DentstageToolApp.Api/CarPlates/CarPlateMaintenanceHistoryRequest.cs
+++ b/src/DentstageToolApp.Api/CarPlates/CarPlateMaintenanceHistoryRequest.cs
@@ -8,5 +8,5 @@ public class CarPlateMaintenanceHistoryRequest
     /// <summary>
     /// 欲查詢的車牌號碼。
     /// </summary>
-    public string LicensePlateNumber { get; set; } = string.Empty;
+    public string CarPlateNumber { get; set; } = string.Empty;
 }

--- a/src/DentstageToolApp.Api/CarPlates/CarPlateMaintenanceHistoryResponse.cs
+++ b/src/DentstageToolApp.Api/CarPlates/CarPlateMaintenanceHistoryResponse.cs
@@ -10,7 +10,7 @@ public class CarPlateMaintenanceHistoryResponse
     /// <summary>
     /// 查詢後使用的正規化車牌號碼，方便前端顯示與後續查詢。
     /// </summary>
-    public string LicensePlateNumber { get; set; } = string.Empty;
+    public string CarPlateNumber { get; set; } = string.Empty;
 
     /// <summary>
     /// 車輛品牌。

--- a/src/DentstageToolApp.Api/CarPlates/CarPlateRecognitionResponse.cs
+++ b/src/DentstageToolApp.Api/CarPlates/CarPlateRecognitionResponse.cs
@@ -8,7 +8,7 @@ public class CarPlateRecognitionResponse
     /// <summary>
     /// 辨識出的車牌號碼。
     /// </summary>
-    public string? LicensePlateNumber { get; set; }
+    public string? CarPlateNumber { get; set; }
 
     /// <summary>
     /// Tesseract 產生的信心度百分比，範圍約為 0-100。

--- a/src/DentstageToolApp.Api/Controllers/CarPlateRecognitionController.cs
+++ b/src/DentstageToolApp.Api/Controllers/CarPlateRecognitionController.cs
@@ -128,7 +128,7 @@ public class CarPlateRecognitionController : ControllerBase
     [SwaggerMockRequestExample(
         """
         {
-          "licensePlateNumber": "AAA-1234"
+          "carPlateNumber": "AAA-1234"
         }
         """)]
     [ProducesResponseType(typeof(CarPlateMaintenanceHistoryResponse), StatusCodes.Status200OK)]
@@ -138,7 +138,7 @@ public class CarPlateRecognitionController : ControllerBase
         [FromBody] CarPlateMaintenanceHistoryRequest request,
         CancellationToken cancellationToken)
     {
-        if (request is null || string.IsNullOrWhiteSpace(request.LicensePlateNumber))
+        if (request is null || string.IsNullOrWhiteSpace(request.CarPlateNumber))
         {
             return BadRequest(new ProblemDetails
             {
@@ -150,7 +150,7 @@ public class CarPlateRecognitionController : ControllerBase
 
         try
         {
-            var result = await _carPlateRecognitionService.GetMaintenanceHistoryAsync(request.LicensePlateNumber, cancellationToken);
+            var result = await _carPlateRecognitionService.GetMaintenanceHistoryAsync(request.CarPlateNumber, cancellationToken);
 
             if (!result.HasMaintenanceRecords)
             {

--- a/src/DentstageToolApp.Api/Services/CarPlate/CarPlateRecognitionService.cs
+++ b/src/DentstageToolApp.Api/Services/CarPlate/CarPlateRecognitionService.cs
@@ -96,7 +96,7 @@ public class CarPlateRecognitionService : ICarPlateRecognitionService
         // ---------- 組裝回應區 ----------
         var response = new CarPlateRecognitionResponse
         {
-            LicensePlateNumber = normalizedPlate,
+            CarPlateNumber = normalizedPlate,
             Confidence = Math.Round(confidence, 2),
             Brand = car?.Brand,
             Model = car?.Model,
@@ -111,15 +111,15 @@ public class CarPlateRecognitionService : ICarPlateRecognitionService
     }
 
     /// <inheritdoc />
-    public async Task<CarPlateMaintenanceHistoryResponse> GetMaintenanceHistoryAsync(string licensePlate, CancellationToken cancellationToken)
+    public async Task<CarPlateMaintenanceHistoryResponse> GetMaintenanceHistoryAsync(string carPlateNumber, CancellationToken cancellationToken)
     {
         // ---------- 參數檢核區 ----------
-        if (string.IsNullOrWhiteSpace(licensePlate))
+        if (string.IsNullOrWhiteSpace(carPlateNumber))
         {
-            throw new ArgumentException("車牌號碼不可為空，請輸入欲查詢的車牌號碼。", nameof(licensePlate));
+            throw new ArgumentException("車牌號碼不可為空，請輸入欲查詢的車牌號碼。", nameof(carPlateNumber));
         }
 
-        var trimmedPlate = licensePlate.Trim();
+        var trimmedPlate = carPlateNumber.Trim();
         var normalizedPlate = NormalizePlate(trimmedPlate);
 
         if (string.IsNullOrWhiteSpace(normalizedPlate))
@@ -193,7 +193,7 @@ public class CarPlateRecognitionService : ICarPlateRecognitionService
 
         var response = new CarPlateMaintenanceHistoryResponse
         {
-            LicensePlateNumber = normalizedPlate,
+            CarPlateNumber = normalizedPlate,
             Brand = car?.Brand ?? referenceOrder?.Brand,
             Model = car?.Model ?? referenceOrder?.Model,
             Color = car?.Color ?? referenceOrder?.Color,

--- a/src/DentstageToolApp.Api/Services/Quotation/QuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/QuotationService.cs
@@ -1,6 +1,10 @@
 using DentstageToolApp.Api.Quotations;
 using DentstageToolApp.Infrastructure.Data;
 using DentstageToolApp.Infrastructure.Entities;
+using CarEntity = DentstageToolApp.Infrastructure.Entities.Car;
+using CustomerEntity = DentstageToolApp.Infrastructure.Entities.Customer;
+using StoreEntity = DentstageToolApp.Infrastructure.Entities.Store;
+using TechnicianEntity = DentstageToolApp.Infrastructure.Entities.Technician;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System;
@@ -515,8 +519,8 @@ public class QuotationService : IQuotationService
     /// </summary>
     private async Task<int?> ResolveStoreIdAsync(
         QuotationStoreInfo storeInfo,
-        Technician? technician,
-        Store? storeEntity,
+        TechnicianEntity? technician,
+        StoreEntity? storeEntity,
         string storeName,
         CancellationToken cancellationToken)
     {
@@ -551,7 +555,7 @@ public class QuotationService : IQuotationService
     /// <summary>
     /// 依據技師識別碼載入技師與所屬門市資料，若未提供識別碼則回傳 null。
     /// </summary>
-    private async Task<Technician?> GetTechnicianEntityAsync(int? technicianId, CancellationToken cancellationToken)
+    private async Task<TechnicianEntity?> GetTechnicianEntityAsync(int? technicianId, CancellationToken cancellationToken)
     {
         if (!technicianId.HasValue)
         {
@@ -574,7 +578,7 @@ public class QuotationService : IQuotationService
     /// <summary>
     /// 根據技師或門市識別碼取得門市主檔資料，確保後續可自動帶入店鋪名稱。
     /// </summary>
-    private async Task<Store?> GetStoreEntityAsync(QuotationStoreInfo storeInfo, Technician? technician, CancellationToken cancellationToken)
+    private async Task<StoreEntity?> GetStoreEntityAsync(QuotationStoreInfo storeInfo, TechnicianEntity? technician, CancellationToken cancellationToken)
     {
         if (technician is not null)
         {
@@ -615,7 +619,7 @@ public class QuotationService : IQuotationService
     /// <summary>
     /// 依據車輛識別碼取得車輛主檔資料，若未提供識別碼則回傳 null。
     /// </summary>
-    private async Task<Car?> GetCarEntityAsync(string? carUid, CancellationToken cancellationToken)
+    private async Task<CarEntity?> GetCarEntityAsync(string? carUid, CancellationToken cancellationToken)
     {
         var normalizedUid = NormalizeOptionalText(carUid);
         if (normalizedUid is null)
@@ -638,7 +642,7 @@ public class QuotationService : IQuotationService
     /// <summary>
     /// 依據客戶識別碼取得客戶主檔資料，若未提供識別碼則回傳 null。
     /// </summary>
-    private async Task<Customer?> GetCustomerEntityAsync(string? customerUid, CancellationToken cancellationToken)
+    private async Task<CustomerEntity?> GetCustomerEntityAsync(string? customerUid, CancellationToken cancellationToken)
     {
         var normalizedUid = NormalizeOptionalText(customerUid);
         if (normalizedUid is null)


### PR DESCRIPTION
## 摘要
- 將車牌維修與辨識相關的請求與回應欄位統一改名為 CarPlateNumber，確保命名一致
- 更新車牌查詢範例與服務實作使用新欄位名稱，避免前後端溝通落差
- 對估價服務新增實體別名別稱，修正技師、客戶與車輛型別被命名空間遮蔽的問題

## 測試
- 未執行（環境無 dotnet CLI）

------
https://chatgpt.com/codex/tasks/task_e_68dcf39c4a808324baa978d708513b74