### PR TITLE
調整估價單建立流程以支援新串接需求

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/PhotosController.cs
+++ b/src/DentstageToolApp.Api/Controllers/PhotosController.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Photos;
+using DentstageToolApp.Api.Services.Photo;
+using DentstageToolApp.Api.Services.Quotation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace DentstageToolApp.Api.Controllers;
+
+/// <summary>
+/// 圖片管理控制器，提供上傳與下載 PhotoUID 的端點。
+/// </summary>
+[ApiController]
+[Route("api/photos")]
+[Authorize]
+public class PhotosController : ControllerBase
+{
+    private readonly IPhotoService _photoService;
+    private readonly ILogger<PhotosController> _logger;
+
+    /// <summary>
+    /// 建構子，注入照片服務與記錄器。
+    /// </summary>
+    public PhotosController(IPhotoService photoService, ILogger<PhotosController> logger)
+    {
+        _photoService = photoService;
+        _logger = logger;
+    }
+
+    // ---------- API 呼叫區 ----------
+
+    /// <summary>
+    /// 上傳圖片並取得 PhotoUID，後續估價單可直接引用此識別碼。
+    /// </summary>
+    [HttpPost]
+    [RequestSizeLimit(50 * 1024 * 1024)]
+    [ProducesResponseType(typeof(UploadPhotoResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<UploadPhotoResponse>> UploadAsync([FromForm] UploadPhotoRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        if (request.File is null)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "缺少圖片檔案",
+                Detail = "請提供要上傳的圖片檔案。",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        try
+        {
+            var response = await _photoService.UploadAsync(request.File, request.Remark, cancellationToken);
+            return CreatedAtAction(nameof(DownloadAsync), new { photoUid = response.PhotoUid }, response);
+        }
+        catch (QuotationManagementException ex)
+        {
+            _logger.LogWarning(ex, "上傳圖片失敗：{Message}", ex.Message);
+            return StatusCode((int)ex.StatusCode, new ProblemDetails
+            {
+                Title = "圖片上傳失敗",
+                Detail = ex.Message,
+                Status = (int)ex.StatusCode
+            });
+        }
+        catch (IOException ex)
+        {
+            _logger.LogError(ex, "寫入圖片檔案時發生錯誤。");
+            return StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetails
+            {
+                Title = "圖片儲存失敗",
+                Detail = "儲存圖片時發生錯誤，請稍後再試。",
+                Status = StatusCodes.Status500InternalServerError
+            });
+        }
+    }
+
+    /// <summary>
+    /// 依 PhotoUID 下載圖片檔案，前端可直接取得原檔供預覽或下載。
+    /// </summary>
+    [HttpGet("{photoUid}")]
+    [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DownloadAsync([FromRoute] string photoUid, CancellationToken cancellationToken)
+    {
+        var photo = await _photoService.GetAsync(photoUid, cancellationToken);
+        if (photo is null)
+        {
+            return NotFound(new ProblemDetails
+            {
+                Title = "找不到圖片",
+                Detail = "指定的圖片不存在或已被移除。",
+                Status = StatusCodes.Status404NotFound
+            });
+        }
+
+        return File(photo.Content, photo.ContentType, photo.FileName);
+    }
+
+    // ---------- 方法區 ----------
+    // 控制器邏輯單純，暫無額外私有方法。
+
+    // ---------- 生命週期 ----------
+    // 控制器由 ASP.NET Core 管理生命週期，無需自行釋放資源。
+}

--- a/src/DentstageToolApp.Api/Controllers/PhotosController.cs
+++ b/src/DentstageToolApp.Api/Controllers/PhotosController.cs
@@ -66,7 +66,7 @@ public class PhotosController : ControllerBase
 
         try
         {
-            var response = await _photoService.UploadAsync(request.File, request.Remark, cancellationToken);
+            var response = await _photoService.UploadAsync(request.File, cancellationToken);
 
             // 由於 CreatedAtAction 需要產生有效路由資訊，若缺少 PhotoUID 則以 200 回應避免例外。
             if (string.IsNullOrWhiteSpace(response.PhotoUid))

--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -99,12 +99,7 @@ public class QuotationsController : ControllerBase
             "carUid": "Ca_805E328B-A461-4D62-B6F7-B7E8D0414842"
           },
           "customer": {
-            "customerUid": "CUST-20240228-0001",
-            "name": "林小華",
-            "phone": "0988123456",
-            "gender": "Male",
-            "source": "Facebook",
-            "remark": "首次諮詢"
+            "customerUid": "Cu_C40A5D87-FD06-48E9-9DB3-1C9677303992"
           },
           "serviceCategories": {
             "dent": {

--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -92,16 +92,8 @@ public class QuotationsController : ControllerBase
         """
         {
           "store": {
-            "storeId": 1,
-            "storeUid": "KH001",
             "technicianId": 12,
-            "storeName": "高雄旗艦店",
-            "estimatorName": "張技師",
-            "creatorName": "王主管",
-            "createdDate": "2024-03-01T10:00:00",
-            "reservationDate": "2024-03-05T15:00:00",
-            "source": "官方網站",
-            "repairDate": "2024-03-08T09:00:00"
+            "source": "官方網站"
           },
           "car": {
             "carUid": "CAR-20240301-0001",

--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -96,12 +96,7 @@ public class QuotationsController : ControllerBase
             "source": "官方網站"
           },
           "car": {
-            "carUid": "CAR-20240301-0001",
-            "licensePlate": "AAA-1234",
-            "brand": "Toyota",
-            "model": "Altis",
-            "color": "銀",
-            "remark": "前保桿有刮傷"
+            "carUid": "Ca_805E328B-A461-4D62-B6F7-B7E8D0414842"
           },
           "customer": {
             "customerUid": "CUST-20240228-0001",

--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -119,7 +119,7 @@ public class QuotationsController : ControllerBase
               },
               "damages": [
                 {
-                  "photo": "dent-front-door.jpg",
+                  "photoUid": "PH_01",
                   "position": "右前門",
                   "dentStatus": "中度凹陷",
                   "description": "需板金搭配烤漆",
@@ -141,8 +141,8 @@ public class QuotationsController : ControllerBase
             "roundingDiscount": 0
           },
           "carBodyConfirmation": {
-            "annotatedImage": "https://cdn.dentstage.com/annotated/car-001.png",
-            "signature": "https://cdn.dentstage.com/signature/customer-001.png"
+            "annotatedPhotoUid": "PH_02",
+            "signaturePhotoUid": "PH_03"
           },
           "remark": "請於修復後通知客戶取車"
         }

--- a/src/DentstageToolApp.Api/Options/PhotoStorageOptions.cs
+++ b/src/DentstageToolApp.Api/Options/PhotoStorageOptions.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace DentstageToolApp.Api.Options;
+
+/// <summary>
+/// 照片儲存設定，控制檔案實際保存路徑與後續擴充選項。
+/// </summary>
+public class PhotoStorageOptions
+{
+    /// <summary>
+    /// 照片儲存目錄，若未設定則預設建立在應用程式資料夾內的 App_Data/photos。
+    /// </summary>
+    public string? RootPath { get; set; }
+}

--- a/src/DentstageToolApp.Api/Photos/UploadPhotoRequest.cs
+++ b/src/DentstageToolApp.Api/Photos/UploadPhotoRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+
+namespace DentstageToolApp.Api.Photos;
+
+/// <summary>
+/// 上傳圖片時的輸入資料結構，支援前端以 multipart/form-data 傳遞檔案與備註。
+/// </summary>
+public class UploadPhotoRequest
+{
+    /// <summary>
+    /// 需上傳的圖片檔案，後端會產出 PhotoUID 作為後續引用識別。
+    /// </summary>
+    [Required(ErrorMessage = "請選擇要上傳的圖片檔案。")]
+    public IFormFile? File { get; set; }
+
+    /// <summary>
+    /// 圖片備註說明，可用於記錄拍攝角度或用途。
+    /// </summary>
+    [MaxLength(500, ErrorMessage = "備註長度不可超過 500 個字元。")]
+    public string? Remark { get; set; }
+}

--- a/src/DentstageToolApp.Api/Photos/UploadPhotoRequest.cs
+++ b/src/DentstageToolApp.Api/Photos/UploadPhotoRequest.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 namespace DentstageToolApp.Api.Photos;
 
 /// <summary>
-/// 上傳圖片時的輸入資料結構，支援前端以 multipart/form-data 傳遞檔案與備註。
+/// 上傳圖片時的輸入資料結構，支援前端以 multipart/form-data 傳遞檔案。
 /// </summary>
 public class UploadPhotoRequest
 {
@@ -14,9 +14,4 @@ public class UploadPhotoRequest
     [Required(ErrorMessage = "請選擇要上傳的圖片檔案。")]
     public IFormFile? File { get; set; }
 
-    /// <summary>
-    /// 圖片備註說明，可用於記錄拍攝角度或用途。
-    /// </summary>
-    [MaxLength(500, ErrorMessage = "備註長度不可超過 500 個字元。")]
-    public string? Remark { get; set; }
 }

--- a/src/DentstageToolApp.Api/Photos/UploadPhotoResponse.cs
+++ b/src/DentstageToolApp.Api/Photos/UploadPhotoResponse.cs
@@ -1,0 +1,27 @@
+namespace DentstageToolApp.Api.Photos;
+
+/// <summary>
+/// 圖片上傳成功後回傳的資訊，提供 PhotoUID 與檔案描述。
+/// </summary>
+public class UploadPhotoResponse
+{
+    /// <summary>
+    /// 圖片唯一識別碼，後續估價單僅需帶入此值即可完成綁定。
+    /// </summary>
+    public string PhotoUid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 原始檔名，方便前端顯示或提示使用者。 
+    /// </summary>
+    public string? FileName { get; set; }
+
+    /// <summary>
+    /// 檔案的 Content-Type，後續下載可直接指定正確 MIME。 
+    /// </summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// 檔案大小（位元組）。
+    /// </summary>
+    public long FileSize { get; set; }
+}

--- a/src/DentstageToolApp.Api/Program.cs
+++ b/src/DentstageToolApp.Api/Program.cs
@@ -10,6 +10,7 @@ using DentstageToolApp.Api.Services.BrandModels;
 using DentstageToolApp.Api.Services.Car;
 using DentstageToolApp.Api.Services.CarPlate;
 using DentstageToolApp.Api.Services.Quotation;
+using DentstageToolApp.Api.Services.Photo;
 using DentstageToolApp.Api.Services.Technician;
 using DentstageToolApp.Api.Services.Customer;
 using DentstageToolApp.Api.Swagger;
@@ -106,6 +107,7 @@ builder.Services.AddDbContext<DentstageToolAppContext>(options =>
 // ---------- JWT 與身份驗證設定 ----------
 builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection("Jwt"));
 builder.Services.Configure<TesseractOcrOptions>(builder.Configuration.GetSection("TesseractOcr"));
+builder.Services.Configure<PhotoStorageOptions>(builder.Configuration.GetSection("PhotoStorage"));
 var jwtOptions = builder.Configuration.GetSection("Jwt").Get<JwtOptions>();
 if (jwtOptions is null || string.IsNullOrWhiteSpace(jwtOptions.Secret))
 {
@@ -146,6 +148,7 @@ builder.Services.AddAuthorization();
 builder.Services.AddScoped<IAccountAdminService, AccountAdminService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IQuotationService, QuotationService>();
+builder.Services.AddScoped<IPhotoService, PhotoService>();
 builder.Services.AddScoped<ICarPlateRecognitionService, CarPlateRecognitionService>();
 builder.Services.AddScoped<ICarManagementService, CarManagementService>();
 builder.Services.AddScoped<IBrandModelQueryService, BrandModelQueryService>();

--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -65,6 +65,8 @@ public class QuotationStoreInfo
     /// <summary>
     /// 技師識別碼，僅需提供此欄位即可自動帶出所屬門市與技師名稱。
     /// </summary>
+    [Required(ErrorMessage = "請選擇估價技師。")]
+    [Range(1, int.MaxValue, ErrorMessage = "請選擇有效的估價技師。")]
     public int? TechnicianId { get; set; }
 
     /// <summary>
@@ -95,6 +97,7 @@ public class QuotationStoreInfo
     /// <summary>
     /// 維修來源。
     /// </summary>
+    [Required(ErrorMessage = "請輸入維修來源。")]
     public string? Source { get; set; }
 
     /// <summary>
@@ -111,6 +114,7 @@ public class QuotationCarInfo
     /// <summary>
     /// 車輛唯一識別碼，若提供則會自動帶出車牌與車況資訊。
     /// </summary>
+    [Required(ErrorMessage = "請選擇車輛資料。")]
     public string? CarUid { get; set; }
 
     /// <summary>
@@ -147,6 +151,7 @@ public class QuotationCustomerInfo
     /// <summary>
     /// 客戶唯一識別碼，若提供則會自動帶出客戶聯絡資料。
     /// </summary>
+    [Required(ErrorMessage = "請選擇客戶資料。")]
     public string? CustomerUid { get; set; }
 
     /// <summary>

--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -12,7 +12,7 @@ public class CreateQuotationRequest
     /// 店家相關資訊。
     /// </summary>
     [Required]
-    public QuotationStoreInfo Store { get; set; } = new();
+    public CreateQuotationStoreInfo Store { get; set; } = new();
 
     /// <summary>
     /// 車輛相關資訊。
@@ -48,7 +48,26 @@ public class CreateQuotationRequest
 }
 
 /// <summary>
-/// 估價單店家資訊欄位。
+/// 建立估價單時，僅需提供技師與來源資訊的店家欄位。
+/// </summary>
+public class CreateQuotationStoreInfo
+{
+    /// <summary>
+    /// 技師識別碼，僅需提供此欄位即可自動帶出所屬門市與技師名稱。
+    /// </summary>
+    [Required(ErrorMessage = "請選擇估價技師。")]
+    [Range(1, int.MaxValue, ErrorMessage = "請選擇有效的估價技師。")]
+    public int? TechnicianId { get; set; }
+
+    /// <summary>
+    /// 維修來源。
+    /// </summary>
+    [Required(ErrorMessage = "請輸入維修來源。")]
+    public string? Source { get; set; }
+}
+
+/// <summary>
+/// 估價單店家資訊欄位（回傳用）。
 /// </summary>
 public class QuotationStoreInfo
 {
@@ -65,8 +84,6 @@ public class QuotationStoreInfo
     /// <summary>
     /// 技師識別碼，僅需提供此欄位即可自動帶出所屬門市與技師名稱。
     /// </summary>
-    [Required(ErrorMessage = "請選擇估價技師。")]
-    [Range(1, int.MaxValue, ErrorMessage = "請選擇有效的估價技師。")]
     public int? TechnicianId { get; set; }
 
     /// <summary>
@@ -97,7 +114,6 @@ public class QuotationStoreInfo
     /// <summary>
     /// 維修來源。
     /// </summary>
-    [Required(ErrorMessage = "請輸入維修來源。")]
     public string? Source { get; set; }
 
     /// <summary>

--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -18,7 +18,7 @@ public class CreateQuotationRequest
     /// 車輛相關資訊。
     /// </summary>
     [Required]
-    public QuotationCarInfo Car { get; set; } = new();
+    public CreateQuotationCarInfo Car { get; set; } = new();
 
     /// <summary>
     /// 客戶相關資訊。
@@ -123,18 +123,29 @@ public class QuotationStoreInfo
 }
 
 /// <summary>
+/// 建立估價單時僅需提供車輛唯一識別碼的精簡輸入結構。
+/// </summary>
+public class CreateQuotationCarInfo
+{
+    /// <summary>
+    /// 車輛唯一識別碼，透過此欄位自動帶入車牌、品牌等細節。
+    /// </summary>
+    [Required(ErrorMessage = "請選擇車輛資料。")]
+    public string? CarUid { get; set; }
+}
+
+/// <summary>
 /// 車輛相關資料欄位。
 /// </summary>
 public class QuotationCarInfo
 {
     /// <summary>
-    /// 車輛唯一識別碼，若提供則會自動帶出車牌與車況資訊。
+    /// 車輛唯一識別碼。
     /// </summary>
-    [Required(ErrorMessage = "請選擇車輛資料。")]
     public string? CarUid { get; set; }
 
     /// <summary>
-    /// 車牌號碼，若未提供會依據車輛主檔自動補齊。
+    /// 車牌號碼。
     /// </summary>
     public string? LicensePlate { get; set; }
 

--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -24,7 +24,7 @@ public class CreateQuotationRequest
     /// 客戶相關資訊。
     /// </summary>
     [Required]
-    public QuotationCustomerInfo Customer { get; set; } = new();
+    public CreateQuotationCustomerInfo Customer { get; set; } = new();
 
     /// <summary>
     /// 服務類別的明細資訊。
@@ -171,7 +171,19 @@ public class QuotationCarInfo
 }
 
 /// <summary>
-/// 客戶相關資料欄位。
+/// 建立估價單時僅需提供客戶唯一識別碼的精簡輸入結構。
+/// </summary>
+public class CreateQuotationCustomerInfo
+{
+    /// <summary>
+    /// 客戶唯一識別碼，透過此欄位自動帶入客戶姓名與聯絡資訊。
+    /// </summary>
+    [Required(ErrorMessage = "請選擇客戶資料。")]
+    public string? CustomerUid { get; set; }
+}
+
+/// <summary>
+/// 客戶相關資料欄位（回傳用）。
 /// </summary>
 public class QuotationCustomerInfo
 {

--- a/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
@@ -217,6 +217,11 @@ public class QuotationCarBodyConfirmation
     public List<QuotationCarBodyChecklistItem> Checklist { get; set; } = new();
 
     /// <summary>
+    /// 車體受損標記列表，透過座標與損傷類型記錄於車身示意圖。
+    /// </summary>
+    public List<QuotationCarBodyDamageMarker> DamageMarkers { get; set; } = new();
+
+    /// <summary>
     /// 舊版欄位，已改為 PhotoUID，保留避免破壞相容性。
     /// </summary>
     [Obsolete("請改用 SignaturePhotoUid 傳遞圖片識別碼。")]
@@ -226,6 +231,11 @@ public class QuotationCarBodyConfirmation
     /// 客戶簽名影像的 PhotoUID。
     /// </summary>
     public string? SignaturePhotoUid { get; set; }
+
+    /// <summary>
+    /// 多份簽名圖片清單，支援一次上傳多張簽名檔並由後端綁定。
+    /// </summary>
+    public List<string> SignaturePhotoUids { get; set; } = new();
 }
 
 /// <summary>
@@ -252,5 +262,41 @@ public class QuotationCarBodyChecklistItem
     /// 單一檢查項目的補充圖片，需傳入 PhotoUID 以便後端綁定。
     /// </summary>
     public List<string> Photos { get; set; } = new();
+}
+
+/// <summary>
+/// 車體受損標記資訊，透過座標定位並標記損傷類型。
+/// </summary>
+public class QuotationCarBodyDamageMarker
+{
+    /// <summary>
+    /// 標記在示意圖上的 X 座標（0~1），用於呈現水平位置。
+    /// </summary>
+    public double? X { get; set; }
+
+    /// <summary>
+    /// 標記在示意圖上的 Y 座標（0~1），用於呈現垂直位置。
+    /// </summary>
+    public double? Y { get; set; }
+
+    /// <summary>
+    /// 是否為凹痕，對應前端勾選的凹痕類型。
+    /// </summary>
+    public bool HasDent { get; set; }
+
+    /// <summary>
+    /// 是否為刮痕，對應前端勾選的刮痕類型。
+    /// </summary>
+    public bool HasScratch { get; set; }
+
+    /// <summary>
+    /// 是否為掉漆，對應前端勾選的掉漆類型。
+    /// </summary>
+    public bool HasPaintPeel { get; set; }
+
+    /// <summary>
+    /// 補充備註，協助記錄詳細損傷描述。
+    /// </summary>
+    public string? Remark { get; set; }
 }
 

--- a/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
@@ -132,9 +132,15 @@ public class QuotationDamageItem
 public class QuotationDamagePhoto
 {
     /// <summary>
-    /// 圖片檔案識別或外部儲存 URL。
+    /// 舊版欄位，改為傳遞 PhotoUID，保留以相容既有流程。
     /// </summary>
+    [Obsolete("請改用 PhotoUid 傳遞圖片識別碼。")]
     public string? File { get; set; }
+
+    /// <summary>
+    /// 圖片唯一識別碼，對應圖片上傳 API 回傳的 PhotoUID。
+    /// </summary>
+    public string? PhotoUid { get; set; }
 
     /// <summary>
     /// 圖片描述，說明拍攝角度或重點標註。
@@ -195,9 +201,15 @@ public class QuotationCategoryTotal
 public class QuotationCarBodyConfirmation
 {
     /// <summary>
-    /// 已標註受損位置的車身圖片，可為檔案識別或 URL。
+    /// 舊版欄位，已改為 PhotoUID，保留避免破壞相容性。
     /// </summary>
+    [Obsolete("請改用 AnnotatedPhotoUid 傳遞圖片識別碼。")]
     public string? AnnotatedImage { get; set; }
+
+    /// <summary>
+    /// 已標註受損位置的車身圖片識別碼。
+    /// </summary>
+    public string? AnnotatedPhotoUid { get; set; }
 
     /// <summary>
     /// 車體確認細項列表，可對應檢查部位與勾選結果。
@@ -205,9 +217,15 @@ public class QuotationCarBodyConfirmation
     public List<QuotationCarBodyChecklistItem> Checklist { get; set; } = new();
 
     /// <summary>
-    /// 客戶簽名影像資料。
+    /// 舊版欄位，已改為 PhotoUID，保留避免破壞相容性。
     /// </summary>
+    [Obsolete("請改用 SignaturePhotoUid 傳遞圖片識別碼。")]
     public string? Signature { get; set; }
+
+    /// <summary>
+    /// 客戶簽名影像的 PhotoUID。
+    /// </summary>
+    public string? SignaturePhotoUid { get; set; }
 }
 
 /// <summary>
@@ -231,7 +249,7 @@ public class QuotationCarBodyChecklistItem
     public string? Remark { get; set; }
 
     /// <summary>
-    /// 單一檢查項目的補充圖片，方便比對局部細節。
+    /// 單一檢查項目的補充圖片，需傳入 PhotoUID 以便後端綁定。
     /// </summary>
     public List<string> Photos { get; set; } = new();
 }

--- a/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationCategoryModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
@@ -94,9 +95,15 @@ public class QuotationCategoryOverallInfo
 public class QuotationDamageItem
 {
     /// <summary>
-    /// 傷痕照片的檔案識別，通常為檔名或外部儲存的 URL。
+    /// 傳統版本僅支援單張照片，保留此欄位以維持相容性。
     /// </summary>
+    [Obsolete("請改用 Photos 集合傳遞多張傷痕圖片。")]
     public string? Photo { get; set; }
+
+    /// <summary>
+    /// 傷痕相關的圖片列表，支援多角度或不同標註的影像。
+    /// </summary>
+    public List<QuotationDamagePhoto> Photos { get; set; } = new();
 
     /// <summary>
     /// 傷痕所在位置描述，例如左前門或後保桿。
@@ -117,6 +124,27 @@ public class QuotationDamageItem
     /// 該傷痕預估的施工金額。
     /// </summary>
     public decimal? EstimatedAmount { get; set; }
+}
+
+/// <summary>
+/// 傷痕影像的補充資訊，可記錄拍攝角度或描述說明。
+/// </summary>
+public class QuotationDamagePhoto
+{
+    /// <summary>
+    /// 圖片檔案識別或外部儲存 URL。
+    /// </summary>
+    public string? File { get; set; }
+
+    /// <summary>
+    /// 圖片描述，說明拍攝角度或重點標註。
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// 是否為主要展示圖片，可協助前端挑選封面影像。
+    /// </summary>
+    public bool? IsPrimary { get; set; }
 }
 
 /// <summary>
@@ -172,8 +200,39 @@ public class QuotationCarBodyConfirmation
     public string? AnnotatedImage { get; set; }
 
     /// <summary>
+    /// 車體確認細項列表，可對應檢查部位與勾選結果。
+    /// </summary>
+    public List<QuotationCarBodyChecklistItem> Checklist { get; set; } = new();
+
+    /// <summary>
     /// 客戶簽名影像資料。
     /// </summary>
     public string? Signature { get; set; }
+}
+
+/// <summary>
+/// 車體確認單的檢查項目，紀錄車身部位與核對狀態。
+/// </summary>
+public class QuotationCarBodyChecklistItem
+{
+    /// <summary>
+    /// 檢查部位或面板名稱，例如左前門或後保桿。
+    /// </summary>
+    public string? Part { get; set; }
+
+    /// <summary>
+    /// 檢查結果或狀態描述，例如正常、待修或已處理。
+    /// </summary>
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// 相關備註，可記錄異常說明或維修建議。
+    /// </summary>
+    public string? Remark { get; set; }
+
+    /// <summary>
+    /// 單一檢查項目的補充圖片，方便比對局部細節。
+    /// </summary>
+    public List<string> Photos { get; set; } = new();
 }
 

--- a/src/DentstageToolApp.Api/Quotations/QuotationOperatorContext.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationOperatorContext.cs
@@ -1,0 +1,17 @@
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 建立估價單時的操作人員資訊，來源為 JWT 權杖的使用者資訊。
+/// </summary>
+public class QuotationOperatorContext
+{
+    /// <summary>
+    /// 操作人員唯一識別碼，用於回填報價單的 UserUid 欄位。
+    /// </summary>
+    public string? UserUid { get; set; }
+
+    /// <summary>
+    /// 操作人員顯示名稱，會同步寫入建立與修改者欄位。
+    /// </summary>
+    public string OperatorName { get; set; } = string.Empty;
+}

--- a/src/DentstageToolApp.Api/Services/Photo/IPhotoService.cs
+++ b/src/DentstageToolApp.Api/Services/Photo/IPhotoService.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Photos;
+using Microsoft.AspNetCore.Http;
+
+namespace DentstageToolApp.Api.Services.Photo;
+
+/// <summary>
+/// 照片服務介面，提供上傳、讀取與綁定估價單的流程。
+/// </summary>
+public interface IPhotoService
+{
+    /// <summary>
+    /// 上傳圖片並產出 PhotoUID，後續可透過此識別碼下載或綁定估價單。
+    /// </summary>
+    /// <param name="file">前端傳遞的圖片檔案。</param>
+    /// <param name="remark">補充說明，會一併寫入照片備註欄位。</param>
+    /// <param name="cancellationToken">取消權杖，供呼叫端中止上傳流程。</param>
+    Task<UploadPhotoResponse> UploadAsync(IFormFile file, string? remark, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 依 PhotoUID 取得圖片檔案內容與對應的 Content-Type。
+    /// </summary>
+    /// <param name="photoUid">圖片唯一識別碼。</param>
+    /// <param name="cancellationToken">取消權杖。</param>
+    Task<PhotoFile?> GetAsync(string photoUid, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 將多張圖片一次綁定至指定估價單，方便建立流程同步寫入關聯。
+    /// </summary>
+    /// <param name="quotationUid">估價單唯一識別碼。</param>
+    /// <param name="photoUids">待綁定的圖片識別碼集合。</param>
+    /// <param name="cancellationToken">取消權杖。</param>
+    Task BindToQuotationAsync(string quotationUid, IEnumerable<string> photoUids, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// 圖片檔案的封裝結果，包含檔名與內容類型，方便控制器直接輸出檔案。
+/// </summary>
+public class PhotoFile
+{
+    /// <summary>
+    /// 建構檔案結果，需提供檔案串流、Content-Type 與下載檔名。
+    /// </summary>
+    public PhotoFile(System.IO.Stream content, string contentType, string fileName)
+    {
+        Content = content;
+        ContentType = contentType;
+        FileName = fileName;
+    }
+
+    /// <summary>
+    /// 圖片內容串流，由呼叫端負責釋放。
+    /// </summary>
+    public System.IO.Stream Content { get; }
+
+    /// <summary>
+    /// 圖片的 Content-Type，預設會依副檔名推論。
+    /// </summary>
+    public string ContentType { get; }
+
+    /// <summary>
+    /// 下載時使用的檔名，預設為原始檔名。
+    /// </summary>
+    public string FileName { get; }
+}

--- a/src/DentstageToolApp.Api/Services/Photo/IPhotoService.cs
+++ b/src/DentstageToolApp.Api/Services/Photo/IPhotoService.cs
@@ -15,9 +15,8 @@ public interface IPhotoService
     /// 上傳圖片並產出 PhotoUID，後續可透過此識別碼下載或綁定估價單。
     /// </summary>
     /// <param name="file">前端傳遞的圖片檔案。</param>
-    /// <param name="remark">補充說明，會一併寫入照片備註欄位。</param>
     /// <param name="cancellationToken">取消權杖，供呼叫端中止上傳流程。</param>
-    Task<UploadPhotoResponse> UploadAsync(IFormFile file, string? remark, CancellationToken cancellationToken);
+    Task<UploadPhotoResponse> UploadAsync(IFormFile file, CancellationToken cancellationToken);
 
     /// <summary>
     /// 依 PhotoUID 取得圖片檔案內容與對應的 Content-Type。

--- a/src/DentstageToolApp.Api/Services/Photo/PhotoService.cs
+++ b/src/DentstageToolApp.Api/Services/Photo/PhotoService.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DentstageToolApp.Api.Options;
+using DentstageToolApp.Api.Photos;
+using DentstageToolApp.Api.Services.Quotation;
+using DentstageToolApp.Infrastructure.Data;
+using DentstageToolApp.Infrastructure.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DentstageToolApp.Api.Services.Photo;
+
+/// <summary>
+/// 照片服務實作，負責處理檔案寫入、讀取與估價單綁定流程。
+/// </summary>
+public class PhotoService : IPhotoService
+{
+    private readonly DentstageToolAppContext _context;
+    private readonly ILogger<PhotoService> _logger;
+    private readonly PhotoStorageOptions _storageOptions;
+    private readonly FileExtensionContentTypeProvider _contentTypeProvider = new();
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// 建構子，注入資料庫內容物件、日誌工具與儲存設定。
+    /// </summary>
+    public PhotoService(
+        DentstageToolAppContext context,
+        ILogger<PhotoService> logger,
+        IOptions<PhotoStorageOptions> storageOptions)
+    {
+        _context = context;
+        _logger = logger;
+        _storageOptions = storageOptions.Value ?? new PhotoStorageOptions();
+    }
+
+    // ---------- API 邏輯區 ----------
+
+    /// <inheritdoc />
+    public async Task<UploadPhotoResponse> UploadAsync(IFormFile file, string? remark, CancellationToken cancellationToken)
+    {
+        if (file is null)
+        {
+            throw new QuotationManagementException(HttpStatusCode.BadRequest, "請提供要上傳的圖片檔案。");
+        }
+
+        if (file.Length <= 0)
+        {
+            throw new QuotationManagementException(HttpStatusCode.BadRequest, "圖片檔案內容為空，請重新選擇檔案。");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var photoUid = GeneratePhotoUid();
+        var extension = NormalizeExtension(Path.GetExtension(file.FileName));
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = GuessExtension(file.ContentType) ?? ".bin";
+        }
+
+        var storageRoot = EnsureStorageRoot();
+        var physicalFileName = photoUid + extension;
+        var physicalPath = Path.Combine(storageRoot, physicalFileName);
+
+        try
+        {
+            // ---------- 檔案寫入區 ----------
+            await using (var stream = new FileStream(physicalPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                await file.CopyToAsync(stream, cancellationToken);
+            }
+
+            // ---------- 資料紀錄區 ----------
+            var contentType = string.IsNullOrWhiteSpace(file.ContentType)
+                ? GuessContentType(extension) ?? "application/octet-stream"
+                : file.ContentType;
+
+            var metadata = new PhotoMetadata
+            {
+                OriginalFileName = file.FileName,
+                ContentType = contentType,
+                FileExtension = extension,
+                Remark = NormalizeRemark(remark)
+            };
+
+            var entity = new PhotoDatum
+            {
+                PhotoUid = photoUid,
+                QuotationUid = null,
+                RelatedUid = null,
+                Comment = JsonSerializer.Serialize(metadata, _jsonOptions),
+                Posion = metadata.Remark
+            };
+
+            await _context.PhotoData.AddAsync(entity, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("成功上傳照片 {PhotoUid}，原始檔名：{FileName}", photoUid, file.FileName);
+
+            return new UploadPhotoResponse
+            {
+                PhotoUid = photoUid,
+                FileName = file.FileName,
+                ContentType = metadata.ContentType,
+                FileSize = file.Length
+            };
+        }
+        catch
+        {
+            // 若資料庫寫入失敗需清理已儲存的檔案，避免孤兒檔案累積。
+            if (File.Exists(physicalPath))
+            {
+                File.Delete(physicalPath);
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<PhotoFile?> GetAsync(string photoUid, CancellationToken cancellationToken)
+    {
+        var normalizedUid = NormalizeUid(photoUid);
+        if (normalizedUid is null)
+        {
+            return null;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var entity = await _context.PhotoData
+            .AsNoTracking()
+            .FirstOrDefaultAsync(photo => photo.PhotoUid == normalizedUid, cancellationToken);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        var metadata = ParseMetadata(entity.Comment);
+        var extension = metadata?.FileExtension ?? ".bin";
+        var storageRoot = EnsureStorageRoot();
+        var physicalPath = Path.Combine(storageRoot, normalizedUid + extension);
+
+        if (!File.Exists(physicalPath))
+        {
+            _logger.LogWarning("找不到照片 {PhotoUid} 的實體檔案，路徑：{Path}", normalizedUid, physicalPath);
+            return null;
+        }
+
+        var contentType = metadata?.ContentType ?? GuessContentType(extension) ?? "application/octet-stream";
+        var downloadFileName = metadata?.OriginalFileName ?? normalizedUid + extension;
+
+        var fileStream = new FileStream(physicalPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return new PhotoFile(fileStream, contentType, downloadFileName);
+    }
+
+    /// <inheritdoc />
+    public async Task BindToQuotationAsync(string quotationUid, IEnumerable<string> photoUids, CancellationToken cancellationToken)
+    {
+        var normalizedQuotationUid = NormalizeUid(quotationUid);
+        if (normalizedQuotationUid is null)
+        {
+            throw new QuotationManagementException(HttpStatusCode.BadRequest, "缺少估價單識別碼，無法綁定圖片。");
+        }
+
+        var normalizedPhotoUids = NormalizePhotoUids(photoUids);
+        if (normalizedPhotoUids.Count == 0)
+        {
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var photos = await _context.PhotoData
+            .Where(photo => normalizedPhotoUids.Contains(photo.PhotoUid))
+            .ToListAsync(cancellationToken);
+
+        var existingUids = new HashSet<string>(photos.Select(photo => photo.PhotoUid), StringComparer.OrdinalIgnoreCase);
+        var missingUids = normalizedPhotoUids
+            .Where(uid => !existingUids.Contains(uid))
+            .ToList();
+
+        if (missingUids.Count > 0)
+        {
+            var missingList = string.Join(", ", missingUids);
+            throw new QuotationManagementException(HttpStatusCode.BadRequest, $"找不到以下圖片識別碼：{missingList}，請確認是否已上傳。");
+        }
+
+        foreach (var photo in photos)
+        {
+            photo.QuotationUid = normalizedQuotationUid;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("共綁定 {Count} 張照片至估價單 {QuotationUid}", photos.Count, normalizedQuotationUid);
+    }
+
+    // ---------- 方法區 ----------
+
+    /// <summary>
+    /// 確保儲存根目錄存在，若無則建立。
+    /// </summary>
+    private string EnsureStorageRoot()
+    {
+        var root = _storageOptions.RootPath;
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            root = Path.Combine(AppContext.BaseDirectory, "App_Data", "photos");
+        }
+
+        if (!Directory.Exists(root))
+        {
+            Directory.CreateDirectory(root);
+        }
+
+        return root;
+    }
+
+    /// <summary>
+    /// 統一產生 PhotoUID，使用 Guid 確保唯一性。
+    /// </summary>
+    private static string GeneratePhotoUid() => $"PH_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// 解析儲存在資料庫中的照片中繼資料。
+    /// </summary>
+    private PhotoMetadata? ParseMetadata(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<PhotoMetadata>(json, _jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "解析照片中繼資料失敗，原始內容：{Json}", json);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 若副檔名缺失時依 Content-Type 推測副檔名。
+    /// </summary>
+    private static string? GuessExtension(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return null;
+        }
+
+        return contentType.Trim().ToLowerInvariant() switch
+        {
+            "image/jpeg" or "image/jpg" => ".jpg",
+            "image/png" => ".png",
+            "image/gif" => ".gif",
+            "image/bmp" => ".bmp",
+            "image/webp" => ".webp",
+            "image/heic" => ".heic",
+            "image/heif" => ".heif",
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// 若 Content-Type 缺失時依副檔名推測。
+    /// </summary>
+    private string? GuessContentType(string? extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return null;
+        }
+
+        if (_contentTypeProvider.TryGetContentType("dummy" + extension, out var contentType))
+        {
+            return contentType;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// 正規化副檔名，確保前面帶有點號且使用小寫。
+    /// </summary>
+    private static string NormalizeExtension(string? extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return string.Empty;
+        }
+
+        extension = extension.Trim();
+        if (!extension.StartsWith('.'))
+        {
+            extension = "." + extension;
+        }
+
+        return extension.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// 正規化備註，若為空白則回傳 null。
+    /// </summary>
+    private static string? NormalizeRemark(string? remark)
+    {
+        if (string.IsNullOrWhiteSpace(remark))
+        {
+            return null;
+        }
+
+        return remark.Trim();
+    }
+
+    /// <summary>
+    /// 正規化 PhotoUID，將空字串視為無效。
+    /// </summary>
+    private static string? NormalizeUid(string? uid)
+    {
+        if (string.IsNullOrWhiteSpace(uid))
+        {
+            return null;
+        }
+
+        return uid.Trim();
+    }
+
+    /// <summary>
+    /// 將傳入集合整理為唯一的 PhotoUID 清單。
+    /// </summary>
+    private static List<string> NormalizePhotoUids(IEnumerable<string> photoUids)
+    {
+        var normalized = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var uid in photoUids)
+        {
+            var normalizedUid = NormalizeUid(uid);
+            if (normalizedUid is not null)
+            {
+                normalized.Add(normalizedUid);
+            }
+        }
+
+        return normalized.ToList();
+    }
+
+    // ---------- 生命週期 ----------
+    // 由 DI 控制生命週期，未持有非受控資源，無需額外釋放。
+
+    /// <summary>
+    /// 照片中繼資料，儲存在資料庫的 Comment 欄位。
+    /// </summary>
+    private class PhotoMetadata
+    {
+        public string? OriginalFileName { get; set; }
+        public string? ContentType { get; set; }
+        public string? FileExtension { get; set; }
+        public string? Remark { get; set; }
+    }
+}

--- a/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
@@ -21,9 +21,9 @@ public interface IQuotationService
     /// 建立估價單並回傳基本資訊。
     /// </summary>
     /// <param name="request">建立所需的欄位資料。</param>
-    /// <param name="operatorName">操作人員名稱，會填入建立與修改者欄位。</param>
+    /// <param name="operatorContext">操作人員上下文資訊，包含使用者識別碼與顯示名稱。</param>
     /// <param name="cancellationToken">取消權杖，支援前端取消請求。</param>
-    Task<CreateQuotationResponse> CreateQuotationAsync(CreateQuotationRequest request, string operatorName, CancellationToken cancellationToken);
+    Task<CreateQuotationResponse> CreateQuotationAsync(CreateQuotationRequest request, QuotationOperatorContext operatorContext, CancellationToken cancellationToken);
 
     /// <summary>
     /// 取得單一估價單的詳細資訊。

--- a/src/DentstageToolApp.Api/Services/Quotation/QuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/QuotationService.cs
@@ -804,6 +804,14 @@ public class QuotationService : IQuotationService
             TryAdd(uniqueUids, body.SignaturePhotoUid);
             TryAdd(uniqueUids, body.Signature);
 
+            if (body.SignaturePhotoUids is { Count: > 0 })
+            {
+                foreach (var signatureUid in body.SignaturePhotoUids)
+                {
+                    TryAdd(uniqueUids, signatureUid);
+                }
+            }
+
             if (body.Checklist is { Count: > 0 })
             {
                 foreach (var item in body.Checklist)

--- a/src/DentstageToolApp.Api/Services/Quotation/QuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/QuotationService.cs
@@ -496,11 +496,12 @@ public class QuotationService : IQuotationService
     }
 
     /// <summary>
-    /// 建立估價單唯一識別碼，使用 Qu_ 前綴搭配 GUID。
+    /// 建立估價單唯一識別碼，使用 Q_ 前綴搭配 GUID。
     /// </summary>
     private static string BuildQuotationUid()
     {
-        return $"Qu_{Guid.NewGuid().ToString().ToUpperInvariant()}";
+        // 以 Q_ 開頭並接續大寫 GUID，對齊前端既有格式需求，方便辨識資料來源。
+        return $"Q_{Guid.NewGuid().ToString().ToUpperInvariant()}";
     }
 
     /// <summary>
@@ -508,7 +509,9 @@ public class QuotationService : IQuotationService
     /// </summary>
     private static string BuildQuotationNo(int serialNumber, DateTime timestamp)
     {
-        return $"Q{timestamp:yyyyMMdd}-{serialNumber:0000}";
+        // 採用 Q + 年份末兩碼 + 月份 + 四碼流水號（例如：Q25070078），
+        // 與舊系統保持一致以便前後端串接查詢。
+        return $"Q{timestamp:yyMM}{serialNumber:0000}";
     }
 
     /// <summary>

--- a/src/DentstageToolApp.Api/appsettings.Development.json
+++ b/src/DentstageToolApp.Api/appsettings.Development.json
@@ -23,5 +23,8 @@
     "Language": "eng",
     "CharacterWhitelist": "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
     "PageSegmentationMode": "SingleBlock"
+  },
+  "PhotoStorage": {
+    "RootPath": "App_Data/photos"
   }
 }

--- a/src/DentstageToolApp.Api/appsettings.json
+++ b/src/DentstageToolApp.Api/appsettings.json
@@ -27,5 +27,8 @@
     "CharacterWhitelist": "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
     "PageSegmentationMode": "SingleBlock"
   },
+  "PhotoStorage": {
+    "RootPath": "App_Data/photos"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## 摘要
- 新增 QuotationOperatorContext 以從 JWT 取得登入者識別並傳遞至服務層
- 強化建立估價單的欄位驗證，限制必填的技師、維修來源、車輛與客戶
- 優化估價單服務邏輯，將登入者資訊寫入 UserUid 並確保維修來源必填

## 測試
- 無法執行 `dotnet build`（容器未提供 dotnet 指令）

------
https://chatgpt.com/codex/tasks/task_e_68dcf5e055e48324b7b471de41ae1ab9