### PR TITLE
後端改用UID綁定門市與主檔資料

### DIFF
--- a/src/DentstageToolApp.Api/BrandModels/BrandModelListResponse.cs
+++ b/src/DentstageToolApp.Api/BrandModels/BrandModelListResponse.cs
@@ -19,9 +19,9 @@ public class BrandModelListResponse
 public class BrandModelItem
 {
     /// <summary>
-    /// 品牌識別碼。
+    /// 品牌識別碼（UID）。
     /// </summary>
-    public int BrandId { get; set; }
+    public string BrandUid { get; set; } = string.Empty;
 
     /// <summary>
     /// 品牌名稱。
@@ -40,9 +40,9 @@ public class BrandModelItem
 public class BrandModelOption
 {
     /// <summary>
-    /// 車型識別碼。
+    /// 車型識別碼（UID）。
     /// </summary>
-    public int ModelId { get; set; }
+    public string ModelUid { get; set; } = string.Empty;
 
     /// <summary>
     /// 車型名稱。

--- a/src/DentstageToolApp.Api/Cars/CreateCarRequest.cs
+++ b/src/DentstageToolApp.Api/Cars/CreateCarRequest.cs
@@ -15,16 +15,16 @@ public class CreateCarRequest
     public string? CarPlateNumber { get; set; }
 
     /// <summary>
-    /// 車輛品牌識別碼，需由前端傳入既有的品牌編號，若無則留空。
+    /// 車輛品牌識別碼，改以 UID 字串傳遞，若無則留空。
     /// </summary>
-    [Range(1, int.MaxValue, ErrorMessage = "品牌識別碼需大於 0。")]
-    public int? BrandId { get; set; }
+    [StringLength(100, ErrorMessage = "品牌識別碼長度不得超過 100 個字元。")]
+    public string? BrandUid { get; set; }
 
     /// <summary>
-    /// 車輛型號識別碼，需搭配品牌編號進行檢核，可留空。
+    /// 車輛型號識別碼，改以 UID 字串傳遞，可留空。
     /// </summary>
-    [Range(1, int.MaxValue, ErrorMessage = "車型識別碼需大於 0。")]
-    public int? ModelId { get; set; }
+    [StringLength(100, ErrorMessage = "車型識別碼長度不得超過 100 個字元。")]
+    public string? ModelUid { get; set; }
 
     /// <summary>
     /// 車色，可留空。

--- a/src/DentstageToolApp.Api/Cars/CreateCarResponse.cs
+++ b/src/DentstageToolApp.Api/Cars/CreateCarResponse.cs
@@ -18,9 +18,9 @@ public class CreateCarResponse
     public string CarPlateNumber { get; set; } = null!;
 
     /// <summary>
-    /// 車輛品牌識別碼，回傳前端所選品牌，若未指定則為 null。
+    /// 車輛品牌識別碼（UID），回傳前端所選品牌，若未指定則為 null。
     /// </summary>
-    public int? BrandId { get; set; }
+    public string? BrandUid { get; set; }
 
     /// <summary>
     /// 車輛品牌或車款資訊。
@@ -33,9 +33,9 @@ public class CreateCarResponse
     public string? Model { get; set; }
 
     /// <summary>
-    /// 車輛型號識別碼，回傳前端所選型號，若未指定則為 null。
+    /// 車輛型號識別碼（UID），回傳前端所選型號，若未指定則為 null。
     /// </summary>
-    public int? ModelId { get; set; }
+    public string? ModelUid { get; set; }
 
     /// <summary>
     /// 車色。

--- a/src/DentstageToolApp.Api/Controllers/TechniciansController.cs
+++ b/src/DentstageToolApp.Api/Controllers/TechniciansController.cs
@@ -53,7 +53,7 @@ public class TechniciansController : ControllerBase
 
         try
         {
-            _logger.LogDebug("查詢店家 {StoreId} 的技師名單。", query.StoreId);
+            _logger.LogDebug("查詢店家 {StoreUid} 的技師名單。", query.StoreUid);
             var response = await _technicianQueryService.GetTechniciansAsync(query, cancellationToken);
             return Ok(response);
         }

--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -53,11 +53,11 @@ public class CreateQuotationRequest
 public class CreateQuotationStoreInfo
 {
     /// <summary>
-    /// 技師識別碼，僅需提供此欄位即可自動帶出所屬門市與技師名稱。
+    /// 技師識別碼，改為以 UID 字串傳遞，可自動帶出所屬門市與技師名稱。
     /// </summary>
     [Required(ErrorMessage = "請選擇估價技師。")]
-    [Range(1, int.MaxValue, ErrorMessage = "請選擇有效的估價技師。")]
-    public int? TechnicianId { get; set; }
+    [StringLength(100, MinimumLength = 1, ErrorMessage = "請選擇有效的估價技師。")]
+    public string? TechnicianUid { get; set; }
 
     /// <summary>
     /// 維修來源。
@@ -72,19 +72,14 @@ public class CreateQuotationStoreInfo
 public class QuotationStoreInfo
 {
     /// <summary>
-    /// 門市識別碼，若有對應主檔可一併傳入。
-    /// </summary>
-    public int? StoreId { get; set; }
-
-    /// <summary>
     /// 門市唯一代碼，可對應舊系統欄位。
     /// </summary>
     public string? StoreUid { get; set; }
 
     /// <summary>
-    /// 技師識別碼，僅需提供此欄位即可自動帶出所屬門市與技師名稱。
+    /// 技師識別碼（UID），可透過此欄位查詢技師主檔。
     /// </summary>
-    public int? TechnicianId { get; set; }
+    public string? TechnicianUid { get; set; }
 
     /// <summary>
     /// 店鋪名稱，若未提供會依據技師或門市主檔自動補齊。

--- a/src/DentstageToolApp.Api/Services/BrandModels/BrandModelQueryService.cs
+++ b/src/DentstageToolApp.Api/Services/BrandModels/BrandModelQueryService.cs
@@ -47,13 +47,13 @@ public class BrandModelQueryService : IBrandModelQueryService
                 .OrderBy(brand => brand.BrandName, StringComparer.CurrentCulture)
                 .Select(brand => new BrandModelItem
                 {
-                    BrandId = brand.BrandId,
+                    BrandUid = brand.BrandUid,
                     BrandName = brand.BrandName,
                     Models = brand.Models
                         .OrderBy(model => model.ModelName, StringComparer.CurrentCulture)
                         .Select(model => new BrandModelOption
                         {
-                            ModelId = model.ModelId,
+                            ModelUid = model.ModelUid,
                             ModelName = model.ModelName
                         })
                         .ToList()

--- a/src/DentstageToolApp.Api/Services/Technician/TechnicianQueryService.cs
+++ b/src/DentstageToolApp.Api/Services/Technician/TechnicianQueryService.cs
@@ -40,9 +40,10 @@ public class TechnicianQueryService : ITechnicianQueryService
                 throw new TechnicianQueryServiceException(HttpStatusCode.BadRequest, "查詢參數不可為空。");
             }
 
-            if (query.StoreId <= 0)
+            var storeUid = query.StoreUid?.Trim();
+            if (string.IsNullOrWhiteSpace(storeUid))
             {
-                // 若店家識別碼小於等於零，代表格式錯誤，直接拋出可預期例外。
+                // 若店家識別碼為空字串，代表格式錯誤，直接拋出可預期例外。
                 throw new TechnicianQueryServiceException(HttpStatusCode.BadRequest, "請提供有效的店家識別碼。");
             }
 
@@ -50,10 +51,10 @@ public class TechnicianQueryService : ITechnicianQueryService
             // 透過技師主檔資料表過濾店家識別碼，並僅保留必要欄位，降低資料傳輸量。
             var technicians = await _dbContext.Technicians
                 .AsNoTracking()
-                .Where(technician => technician.StoreId == query.StoreId)
+                .Where(technician => technician.StoreUid == storeUid)
                 .Select(technician => new TechnicianItem
                 {
-                    TechnicianId = technician.TechnicianId,
+                    TechnicianUid = technician.TechnicianUid,
                     TechnicianName = technician.TechnicianName
                 })
                 // EF Core 無法直接翻譯帶有 Comparer 的排序，改用預設排序以確保查詢可被翻譯。 

--- a/src/DentstageToolApp.Api/Technicians/TechnicianListQuery.cs
+++ b/src/DentstageToolApp.Api/Technicians/TechnicianListQuery.cs
@@ -8,9 +8,9 @@ namespace DentstageToolApp.Api.Technicians;
 public class TechnicianListQuery
 {
     /// <summary>
-    /// 店家識別碼，僅接受正整數，代表欲查詢的門市。
+    /// 店家識別碼，改為以 UID 字串傳遞，長度限制 100 字元以內。
     /// </summary>
     [Required(ErrorMessage = "請提供店家識別碼。")]
-    [Range(1, int.MaxValue, ErrorMessage = "店家識別碼格式不正確。")]
-    public int StoreId { get; set; }
+    [StringLength(100, MinimumLength = 1, ErrorMessage = "店家識別碼格式不正確。")]
+    public string StoreUid { get; set; } = string.Empty;
 }

--- a/src/DentstageToolApp.Api/Technicians/TechnicianListResponse.cs
+++ b/src/DentstageToolApp.Api/Technicians/TechnicianListResponse.cs
@@ -19,9 +19,9 @@ public class TechnicianListResponse
 public class TechnicianItem
 {
     /// <summary>
-    /// 技師識別碼，對應後端技師主鍵。
+    /// 技師識別碼，改為技師 UID。
     /// </summary>
-    public int TechnicianId { get; set; }
+    public string TechnicianUid { get; set; } = string.Empty;
 
     /// <summary>
     /// 技師姓名，提供前端顯示。

--- a/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
+++ b/src/DentstageToolApp.Infrastructure/Data/DentstageToolAppContext.cs
@@ -267,12 +267,13 @@ public class DentstageToolAppContext : DbContext
     {
         var entity = modelBuilder.Entity<Brand>();
         entity.ToTable("Brands");
-        entity.HasKey(e => e.BrandId);
-        entity.Property(e => e.BrandId)
-            .HasColumnName("BrandId");
+        entity.HasKey(e => e.BrandUid);
+        entity.Property(e => e.BrandUid)
+            .HasMaxLength(100)
+            .HasColumnName("BrandUID");
         entity.Property(e => e.BrandName)
             .IsRequired()
-            .HasMaxLength(50);
+            .HasMaxLength(100);
     }
 
     /// <summary>
@@ -282,17 +283,19 @@ public class DentstageToolAppContext : DbContext
     {
         var entity = modelBuilder.Entity<Model>();
         entity.ToTable("Models");
-        entity.HasKey(e => e.ModelId);
-        entity.Property(e => e.ModelId)
-            .HasColumnName("ModelId");
+        entity.HasKey(e => e.ModelUid);
+        entity.Property(e => e.ModelUid)
+            .HasMaxLength(100)
+            .HasColumnName("ModelUID");
         entity.Property(e => e.ModelName)
             .IsRequired()
             .HasMaxLength(100);
-        entity.Property(e => e.BrandId)
-            .HasColumnName("BrandId");
+        entity.Property(e => e.BrandUid)
+            .HasMaxLength(100)
+            .HasColumnName("BrandUID");
         entity.HasOne(e => e.Brand)
             .WithMany(e => e.Models)
-            .HasForeignKey(e => e.BrandId)
+            .HasForeignKey(e => e.BrandUid)
             .OnDelete(DeleteBehavior.Cascade);
     }
 
@@ -303,13 +306,16 @@ public class DentstageToolAppContext : DbContext
     {
         var entity = modelBuilder.Entity<FixType>();
         entity.ToTable("fix_types");
-        entity.HasKey(e => e.FixTypeId);
+        entity.HasKey(e => e.FixTypeUid);
+        entity.Property(e => e.FixTypeUid)
+            .HasMaxLength(100)
+            .HasColumnName("FixTypeUID");
         entity.Property(e => e.FixTypeName)
             .IsRequired()
-            .HasMaxLength(50);
+            .HasMaxLength(100);
         entity.HasMany(e => e.Quatations)
             .WithOne(e => e.FixTypeNavigation)
-            .HasForeignKey(e => e.FixTypeId)
+            .HasForeignKey(e => e.FixTypeUid)
             .OnDelete(DeleteBehavior.SetNull);
     }
 
@@ -320,17 +326,20 @@ public class DentstageToolAppContext : DbContext
     {
         var entity = modelBuilder.Entity<Store>();
         entity.ToTable("stores");
-        entity.HasKey(e => e.StoreId);
+        entity.HasKey(e => e.StoreUid);
+        entity.Property(e => e.StoreUid)
+            .HasMaxLength(100)
+            .HasColumnName("StoreUID");
         entity.Property(e => e.StoreName)
             .IsRequired()
             .HasMaxLength(100);
         entity.HasMany(e => e.Technicians)
             .WithOne(e => e.Store)
-            .HasForeignKey(e => e.StoreId)
+            .HasForeignKey(e => e.StoreUid)
             .OnDelete(DeleteBehavior.Cascade);
         entity.HasMany(e => e.Quatations)
             .WithOne(e => e.StoreNavigation)
-            .HasForeignKey(e => e.StoreId)
+            .HasForeignKey(e => e.StoreUid)
             .OnDelete(DeleteBehavior.SetNull);
     }
 
@@ -341,18 +350,23 @@ public class DentstageToolAppContext : DbContext
     {
         var entity = modelBuilder.Entity<Technician>();
         entity.ToTable("technicians");
-        entity.HasKey(e => e.TechnicianId);
+        entity.HasKey(e => e.TechnicianUid);
+        entity.Property(e => e.TechnicianUid)
+            .HasMaxLength(100)
+            .HasColumnName("TechnicianUID");
         entity.Property(e => e.TechnicianName)
             .IsRequired()
             .HasMaxLength(100);
-        entity.Property(e => e.StoreId).IsRequired();
+        entity.Property(e => e.StoreUid)
+            .HasMaxLength(100)
+            .HasColumnName("StoreUID");
         entity.HasOne(e => e.Store)
             .WithMany(e => e.Technicians)
-            .HasForeignKey(e => e.StoreId)
+            .HasForeignKey(e => e.StoreUid)
             .OnDelete(DeleteBehavior.Cascade);
         entity.HasMany(e => e.Quatations)
             .WithOne(e => e.TechnicianNavigation)
-            .HasForeignKey(e => e.TechnicianId)
+            .HasForeignKey(e => e.TechnicianUid)
             .OnDelete(DeleteBehavior.SetNull);
     }
 
@@ -370,19 +384,21 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.QuotationNo).HasMaxLength(50);
         entity.Property(e => e.CreatedBy).HasMaxLength(50);
         entity.Property(e => e.ModifiedBy).HasMaxLength(50);
-        entity.Property(e => e.StoreUid).HasMaxLength(100);
+        entity.Property(e => e.StoreUid)
+            .HasMaxLength(100)
+            .HasColumnName("StoreUID");
         entity.Property(e => e.UserUid).HasMaxLength(100);
         entity.Property(e => e.UserName).HasMaxLength(100);
-        entity.Property(e => e.StoreId)
-            .HasColumnName("StoreId");
-        entity.Property(e => e.TechnicianId)
-            .HasColumnName("TechnicianId");
+        entity.Property(e => e.TechnicianUid)
+            .HasMaxLength(100)
+            .HasColumnName("TechnicianUID");
         entity.Property(e => e.Status).HasMaxLength(20);
         entity.Property(e => e.FixType)
             .HasMaxLength(50)
             .HasColumnName("Fix_Type");
-        entity.Property(e => e.FixTypeId)
-            .HasColumnName("FixTypeId");
+        entity.Property(e => e.FixTypeUid)
+            .HasMaxLength(100)
+            .HasColumnName("FixTypeUID");
         entity.Property(e => e.CarUid)
             .HasMaxLength(100)
             .HasColumnName("CarUID");
@@ -395,10 +411,12 @@ public class DentstageToolAppContext : DbContext
         entity.Property(e => e.CarNo).HasMaxLength(50);
         entity.Property(e => e.Brand).HasMaxLength(50);
         entity.Property(e => e.Model).HasMaxLength(50);
-        entity.Property(e => e.BrandId)
-            .HasColumnName("BrandId");
-        entity.Property(e => e.ModelId)
-            .HasColumnName("ModelId");
+        entity.Property(e => e.BrandUid)
+            .HasMaxLength(100)
+            .HasColumnName("BrandUID");
+        entity.Property(e => e.ModelUid)
+            .HasMaxLength(100)
+            .HasColumnName("ModelUID");
         entity.Property(e => e.Color).HasMaxLength(20);
         entity.Property(e => e.CarRemark)
             .HasMaxLength(255)
@@ -408,23 +426,23 @@ public class DentstageToolAppContext : DbContext
             .HasColumnName("Brand_Model");
         entity.HasOne(e => e.BrandNavigation)
             .WithMany(e => e.Quatations)
-            .HasForeignKey(e => e.BrandId)
+            .HasForeignKey(e => e.BrandUid)
             .OnDelete(DeleteBehavior.SetNull);
         entity.HasOne(e => e.ModelNavigation)
             .WithMany(e => e.Quatations)
-            .HasForeignKey(e => e.ModelId)
+            .HasForeignKey(e => e.ModelUid)
             .OnDelete(DeleteBehavior.SetNull);
         entity.HasOne(e => e.FixTypeNavigation)
             .WithMany(e => e.Quatations)
-            .HasForeignKey(e => e.FixTypeId)
+            .HasForeignKey(e => e.FixTypeUid)
             .OnDelete(DeleteBehavior.SetNull);
         entity.HasOne(e => e.StoreNavigation)
             .WithMany(e => e.Quatations)
-            .HasForeignKey(e => e.StoreId)
+            .HasForeignKey(e => e.StoreUid)
             .OnDelete(DeleteBehavior.SetNull);
         entity.HasOne(e => e.TechnicianNavigation)
             .WithMany(e => e.Quatations)
-            .HasForeignKey(e => e.TechnicianId)
+            .HasForeignKey(e => e.TechnicianUid)
             .OnDelete(DeleteBehavior.SetNull);
         entity.Property(e => e.CustomerUid)
             .HasMaxLength(100)

--- a/src/DentstageToolApp.Infrastructure/Entities/Brand.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/Brand.cs
@@ -8,9 +8,9 @@ namespace DentstageToolApp.Infrastructure.Entities;
 public class Brand
 {
     /// <summary>
-    /// 品牌識別碼，資料表主鍵。
+    /// 品牌識別碼，資料表主鍵改為 UID 字串。
     /// </summary>
-    public int BrandId { get; set; }
+    public string BrandUid { get; set; } = null!;
 
     /// <summary>
     /// 品牌名稱。

--- a/src/DentstageToolApp.Infrastructure/Entities/FixType.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/FixType.cs
@@ -8,9 +8,9 @@ namespace DentstageToolApp.Infrastructure.Entities;
 public class FixType
 {
     /// <summary>
-    /// 維修類型主鍵。
+    /// 維修類型主鍵，改為 UID 字串，對應 FixTypeUID。
     /// </summary>
-    public int FixTypeId { get; set; }
+    public string FixTypeUid { get; set; } = null!;
 
     /// <summary>
     /// 維修類型名稱，例如凹痕、鈑烤等。

--- a/src/DentstageToolApp.Infrastructure/Entities/Model.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/Model.cs
@@ -8,14 +8,14 @@ namespace DentstageToolApp.Infrastructure.Entities;
 public class Model
 {
     /// <summary>
-    /// 車型識別碼，資料表主鍵。
+    /// 車型識別碼，資料表主鍵改為 UID 字串。
     /// </summary>
-    public int ModelId { get; set; }
+    public string ModelUid { get; set; } = null!;
 
     /// <summary>
-    /// 對應品牌識別碼。
+    /// 對應品牌識別碼，改為以品牌 UID 串接品牌主檔。
     /// </summary>
-    public int BrandId { get; set; }
+    public string? BrandUid { get; set; }
 
     /// <summary>
     /// 車型名稱。

--- a/src/DentstageToolApp.Infrastructure/Entities/Quatation.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/Quatation.cs
@@ -59,19 +59,14 @@ public class Quatation
     public string? UserName { get; set; }
 
     /// <summary>
-    /// 所屬門市識別碼。
-    /// </summary>
-    public int? StoreId { get; set; }
-
-    /// <summary>
     /// 導覽屬性：門市主檔資料。
     /// </summary>
     public Store? StoreNavigation { get; set; }
 
     /// <summary>
-    /// 建立估價單的技師識別碼。
+    /// 建立估價單的技師識別碼（UID）。
     /// </summary>
-    public int? TechnicianId { get; set; }
+    public string? TechnicianUid { get; set; }
 
     /// <summary>
     /// 導覽屬性：技師主檔資料。
@@ -94,9 +89,9 @@ public class Quatation
     public string? FixType { get; set; }
 
     /// <summary>
-    /// 維修類型識別碼，對應 fix_types 表格主鍵。
+    /// 維修類型識別碼（UID），對應 fix_types 表格主鍵。
     /// </summary>
-    public int? FixTypeId { get; set; }
+    public string? FixTypeUid { get; set; }
 
     /// <summary>
     /// 導覽屬性：維修類型主檔資料。
@@ -134,14 +129,14 @@ public class Quatation
     public string? Model { get; set; }
 
     /// <summary>
-    /// 車輛品牌識別碼，對應 Brands 表格主鍵。
+    /// 車輛品牌識別碼（UID），對應 Brands 表格主鍵。
     /// </summary>
-    public int? BrandId { get; set; }
+    public string? BrandUid { get; set; }
 
     /// <summary>
-    /// 車輛型號識別碼，對應 Models 表格主鍵。
+    /// 車輛型號識別碼（UID），對應 Models 表格主鍵。
     /// </summary>
-    public int? ModelId { get; set; }
+    public string? ModelUid { get; set; }
 
     /// <summary>
     /// 導覽屬性：報價單所關聯的品牌資料。

--- a/src/DentstageToolApp.Infrastructure/Entities/Store.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/Store.cs
@@ -8,9 +8,9 @@ namespace DentstageToolApp.Infrastructure.Entities;
 public class Store
 {
     /// <summary>
-    /// 門市主鍵識別碼。
+    /// 門市主鍵識別碼，改以 UID 字串表示，對應資料表欄位 StoreUID。
     /// </summary>
-    public int StoreId { get; set; }
+    public string StoreUid { get; set; } = null!;
 
     /// <summary>
     /// 門市名稱。

--- a/src/DentstageToolApp.Infrastructure/Entities/Technician.cs
+++ b/src/DentstageToolApp.Infrastructure/Entities/Technician.cs
@@ -8,9 +8,9 @@ namespace DentstageToolApp.Infrastructure.Entities;
 public class Technician
 {
     /// <summary>
-    /// 技師主鍵識別碼。
+    /// 技師主鍵識別碼，改以 UID 字串表示，對應資料表欄位 TechnicianUID。
     /// </summary>
-    public int TechnicianId { get; set; }
+    public string TechnicianUid { get; set; } = null!;
 
     /// <summary>
     /// 技師姓名。
@@ -18,14 +18,14 @@ public class Technician
     public string TechnicianName { get; set; } = null!;
 
     /// <summary>
-    /// 所屬門市識別碼，對應 stores 表的主鍵。
+    /// 所屬門市識別碼，改為以 UID 字串串接門市主檔。
     /// </summary>
-    public int StoreId { get; set; }
+    public string? StoreUid { get; set; }
 
     /// <summary>
     /// 導覽屬性：技師所屬的門市資料。
     /// </summary>
-    public Store Store { get; set; } = null!;
+    public Store? Store { get; set; }
 
     /// <summary>
     /// 導覽屬性：由該技師負責的估價單清單。


### PR DESCRIPTION
## 摘要
- 將門市、技師、品牌、車型、維修類型主檔改為使用 UID 主鍵並同步更新實體與資料庫模型設定
- 更新車輛、估價單與技師相關 API 輸入輸出模型，改以 UID 傳遞並調整查詢與建立邏輯
- 調整品牌車型查詢與技師清單服務，回傳 UID 以支援前端新綁定方式

## 測試
- dotnet build（環境未提供 dotnet CLI，無法執行）

------
https://chatgpt.com/codex/tasks/task_e_68de2233656c832489dee0dfafa212c5