### PR TITLE
後端：估價單改用使用者UID顯示估價人員

### DIFF
--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -48,12 +48,13 @@ public class CreateQuotationRequest
 }
 
 /// <summary>
-/// 建立估價單時，僅需提供技師與來源資訊的店家欄位。
+/// 建立估價單時，僅需提供操作者與來源資訊的店家欄位。
 /// </summary>
 public class CreateQuotationStoreInfo
 {
     /// <summary>
     /// 技師識別碼，改為以 UID 字串傳遞，可自動帶出所屬門市與技師名稱。
+    /// （後端仍保留舊欄位，待前端改版後可進一步移除。）
     /// </summary>
     [Required(ErrorMessage = "請選擇估價技師。")]
     [StringLength(100, MinimumLength = 1, ErrorMessage = "請選擇有效的估價技師。")]
@@ -77,17 +78,17 @@ public class QuotationStoreInfo
     public string? StoreUid { get; set; }
 
     /// <summary>
-    /// 技師識別碼（UID），可透過此欄位查詢技師主檔。
+    /// 建立估價單的使用者識別碼（UID），供前端回填操作者資訊。
     /// </summary>
-    public string? TechnicianUid { get; set; }
+    public string? UserUid { get; set; }
 
     /// <summary>
-    /// 店鋪名稱，若未提供會依據技師或門市主檔自動補齊。
+    /// 店鋪名稱，若未提供會依據使用者或門市主檔自動補齊。
     /// </summary>
     public string? StoreName { get; set; }
 
     /// <summary>
-    /// 估價技師。
+    /// 估價人員。
     /// </summary>
     public string? EstimatorName { get; set; }
 

--- a/src/DentstageToolApp.Api/Quotations/QuotationSummaryResponse.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationSummaryResponse.cs
@@ -53,7 +53,7 @@ public class QuotationSummaryResponse
     public string? StoreName { get; set; }
 
     /// <summary>
-    /// 估價技師姓名，優先採用技師主檔資料，若無則使用估價單原欄位。
+    /// 估價人員姓名，優先採用使用者主檔資料，若無則使用估價單原欄位。
     /// </summary>
     public string? EstimatorName { get; set; }
 


### PR DESCRIPTION
## 摘要
- 估價單列表改以 UserUid 批次查詢使用者顯示名稱，若查無對應則回退至原本的 UserName
- 詳細頁改以 UserUid 讀取使用者主檔並回填估價人員資訊，同樣保留 UserName 備援
- 店家資訊回傳欄位調整為 UserUid 並更新相關中文註解說明

## 測試
- `dotnet build`（失敗，容器缺少 dotnet 指令）

------
https://chatgpt.com/codex/tasks/task_e_68de320820148324a2e24c5f26c59060