### PR TITLE
新增估價單建立預約與維修日期欄位

### DIFF
--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -65,6 +65,16 @@ public class CreateQuotationStoreInfo
     /// </summary>
     [Required(ErrorMessage = "請輸入維修來源。")]
     public string? Source { get; set; }
+
+    /// <summary>
+    /// 預約日期，允許前端依需求傳入，若為空則代表尚未排定。
+    /// </summary>
+    public DateTime? ReservationDate { get; set; }
+
+    /// <summary>
+    /// 預計維修日期，允許前端依需求傳入，若為空則代表尚未排程。
+    /// </summary>
+    public DateTime? RepairDate { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## 摘要
- 建立估價單請求結構新增預約與維修日期欄位，方便前端於建單時一併送出
- 建立估價單服務正規化可選日期欄位，寫入資料庫時轉換為 DateOnly 型別

## 測試
- 未執行（依專案規範可直接提交）

------
https://chatgpt.com/codex/tasks/task_e_68de378be774832484692f23a66e7991