### PR TITLE
修正估價單建立支援舊版傷痕資料格式

### DIFF
--- a/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace DentstageToolApp.Api.Quotations;
 
@@ -29,7 +30,9 @@ public class CreateQuotationRequest
 
     /// <summary>
     /// 傷痕細項列表，改為獨立於類別之外集中管理，便於前端統一渲染表格。
+    /// 透過自訂轉換器支援舊版單物件與新版陣列格式，降低前端調整負擔。
     /// </summary>
+    [JsonConverter(typeof(QuotationDamageCollectionConverter))]
     public List<QuotationDamageItem> Damages { get; set; } = new();
 
     /// <summary>


### PR DESCRIPTION
## 摘要
- 調整建立估價單的 damages 欄位套用 QuotationDamageCollectionConverter，支援舊版單一物件與新版陣列格式
- 補充中文註解說明轉換器用途，協助維運理解修改目的

## 測試
- 未執行自動化測試（依專案規範允許）

------
https://chatgpt.com/codex/tasks/task_e_68df35e3785c832491c3c3309fa18fb0