### PR TITLE
同步傷痕圖片資訊與簽名標記

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -243,7 +243,50 @@ public class QuotationsController : ControllerBase
             "dent": "追加處理左後門凹痕",
             "paint": "等待調色"
           },
-          "remark": "預計 3/8 完成"
+          "remark": "預計 3/8 完成",
+          "damages": [
+            {
+              "圖片": [
+                {
+                  "photoUid": "Ph_40F81F71-19C4-48FF-AC6A-1CFB07B8BE9B",
+                  "description": "正面照"
+                }
+              ],
+              "位置": "後保桿",
+              "凹痕狀況": "輕微凹陷",
+              "說明": "需拆卸調整並搭配烤漆",
+              "預估金額": 3500
+            }
+          ],
+          "carBodyConfirmation": {
+            "signaturePhotoUid": "Ph_9973BFA3-2E36-45F2-9BDE-AB1D6B7F73B1",
+            "damageMarkers": [
+              {
+                "x": 0.35,
+                "y": 0.62,
+                "hasDent": true,
+                "hasScratch": false,
+                "hasPaintPeel": false,
+                "remark": "主要受損位置"
+              }
+            ]
+          },
+          "maintenance": {
+            "fixTypeUid": "F_9C2EDFDA-9F5A-11F0-A812-000C2990DEAF",
+            "reserveCar": false,
+            "applyCoating": false,
+            "applyWrapping": false,
+            "hasRepainted": false,
+            "needToolEvaluation": true,
+            "otherFee": 500,
+            "roundingDiscount": 0,
+            "percentageDiscount": 5,
+            "discountReason": "老客戶回訪",
+            "estimatedRepairDays": 1,
+            "estimatedRepairHours": 6,
+            "estimatedRestorationPercentage": 90,
+            "remark": "更新備註內容"
+          }
         }
         """)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -299,7 +342,8 @@ public class QuotationsController : ControllerBase
         return new QuotationOperatorContext
         {
             OperatorName = GetCurrentOperatorName(),
-            UserUid = GetCurrentUserUid()
+            UserUid = GetCurrentUserUid(),
+            StoreUid = GetCurrentStoreUid()
         };
     }
 
@@ -349,6 +393,25 @@ public class QuotationsController : ControllerBase
 
         userUid = User.FindFirstValue(ClaimTypes.NameIdentifier);
         return string.IsNullOrWhiteSpace(userUid) ? null : userUid;
+    }
+
+    /// <summary>
+    /// 從 JWT 權杖中取出門市識別碼，支援多種常見的 Claim Key 寫法。
+    /// </summary>
+    private string? GetCurrentStoreUid()
+    {
+        // 依序檢查常見欄位名稱，確保不同登入來源皆可正確回傳門市 UID。
+        var claimKeys = new[] { "storeUid", "StoreUid", "storeUID", "StoreUID", "storeId", "StoreId" };
+        foreach (var key in claimKeys)
+        {
+            var value = User.FindFirstValue(key);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
     }
 
     // ---------- 生命週期 ----------

--- a/src/DentstageToolApp.Api/Quotations/QuotationOperatorContext.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationOperatorContext.cs
@@ -14,4 +14,9 @@ public class QuotationOperatorContext
     /// 操作人員顯示名稱，會同步寫入建立與修改者欄位。
     /// </summary>
     public string OperatorName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 操作人員所屬門市識別碼，來源為 JWT 權杖內的 StoreUid，建檔時須帶入報價單的 StoreUID 欄位。
+    /// </summary>
+    public string? StoreUid { get; set; }
 }

--- a/src/DentstageToolApp.Api/Quotations/UpdateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/UpdateQuotationRequest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace DentstageToolApp.Api.Quotations;
 
@@ -36,5 +37,21 @@ public class UpdateQuotationRequest
     /// 若需要同步更新估價單整體備註可一併傳入。
     /// </summary>
     public string? Remark { get; set; }
+
+    /// <summary>
+    /// 傷痕細項列表，沿用建立與詳情回傳的結構，確保欄位一致。
+    /// </summary>
+    [JsonConverter(typeof(QuotationDamageCollectionConverter))]
+    public List<QuotationDamageItem> Damages { get; set; } = new();
+
+    /// <summary>
+    /// 車體確認單資料，包含標記與簽名資訊。
+    /// </summary>
+    public QuotationCarBodyConfirmation? CarBodyConfirmation { get; set; }
+
+    /// <summary>
+    /// 維修設定資訊，與詳情回傳欄位同步，方便前端直接提交完整資料。
+    /// </summary>
+    public QuotationMaintenanceInfo? Maintenance { get; set; }
 }
 


### PR DESCRIPTION
## 摘要
- 建立與更新估價單時改以 remark 擴充結構保存傷痕、簽名與折扣資料，並將傷痕欄位同步寫回照片主檔
- 更新估價單服務支援同步修改 damages、車體確認單與維修設定，並依照片主檔回填舊資料欄位
- 編輯估價單範例與請求模型補齊 damages、carBodyConfirmation、maintenance 欄位，使詳情與編輯介面欄位一致

## 測試
- 無（環境缺少 dotnet 指令）

------
https://chatgpt.com/codex/tasks/task_e_68df35e3785c832491c3c3309fa18fb0