### PR TITLE
新增估價單狀態操作流程

### DIFF
--- a/docs/quotation-edit-guide.html
+++ b/docs/quotation-edit-guide.html
@@ -70,7 +70,7 @@
     <h2>流程概觀</h2>
     <ol>
       <li><strong>取得既有估價單資料：</strong>建議先呼叫 <code>POST /api/quotations/detail</code> 取得完整資料，避免覆蓋舊值。</li>
-      <li><strong>確認唯一識別：</strong>可使用 <code>quotationUid</code> 或 <code>quotationNo</code> 任一值鎖定目標估價單。</li>
+      <li><strong>確認唯一識別：</strong>後端以 <code>quotationNo</code> 作為唯一識別，請確保帶入正確編號。</li>
       <li><strong>整理欲更新欄位：</strong>依下方欄位對照表組裝 JSON，僅需傳入需變動的欄位即可。</li>
       <li><strong>送出 API 請求：</strong>以 <code>application/json</code> 內容呼叫 <code>POST /api/quotations/edit</code>，成功會回傳 204。</li>
       <li><strong>重新取得最新內容：</strong>更新後可再次查詢詳情，確認資料已同步。</li>
@@ -94,14 +94,9 @@
       </thead>
       <tbody>
         <tr>
-          <td><code>quotationUid</code></td>
-          <td>估價單唯一識別碼。</td>
-          <td>選填欄位，若已掌握 UID，建議優先使用以避免編號重覆。</td>
-        </tr>
-        <tr>
           <td><code>quotationNo</code></td>
           <td>估價單編號。</td>
-          <td>必填欄位（或搭配 UID 其中一項），可從列表或詳情取得。</td>
+          <td>必填欄位，可從列表或詳情取得後直接帶入。</td>
         </tr>
         <tr>
           <td><code>store.technicianUid</code></td>
@@ -293,8 +288,8 @@
   <section>
     <h2>常見錯誤與排除方式</h2>
     <ul>
-      <li><strong>400 驗證錯誤：</strong>確認至少提供 <code>quotationUid</code> 或 <code>quotationNo</code>，並檢查 JSON 結構是否符合 Swagger。</li>
-      <li><strong>找不到估價單：</strong>若回應 404，請確認編號或 UID 是否存在，必要時重新查詢列表。</li>
+      <li><strong>400 驗證錯誤：</strong>確認請求已提供 <code>quotationNo</code>，並檢查 JSON 結構是否符合 Swagger。</li>
+      <li><strong>找不到估價單：</strong>若回應 404，請確認編號是否存在，必要時重新查詢列表。</li>
       <li><strong>資料被覆蓋：</strong>更新前先取得詳情，僅傳遞需要變動的欄位，避免覆寫既有內容。</li>
     </ul>
   </section>

--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -311,6 +311,13 @@ public class QuotationsController : ControllerBase
     /// 取消估價單，將狀態改為 195 並記錄操作時間。
     /// </summary>
     [HttpPost("cancel")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationNo": "Q25100001",
+          "reason": "客戶臨時改期"
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationStatusChangeResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<QuotationStatusChangeResponse>> CancelQuotationAsync([FromBody] QuotationCancelRequest request, CancellationToken cancellationToken)
     {
@@ -346,6 +353,13 @@ public class QuotationsController : ControllerBase
     /// 將估價單轉為預約，寫入預約日期後回傳狀態資訊。
     /// </summary>
     [HttpPost("reserve")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationNo": "Q25100001",
+          "reservationDate": "2024-11-20T10:00:00"
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationStatusChangeResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<QuotationStatusChangeResponse>> ConvertToReservationAsync([FromBody] QuotationReservationRequest request, CancellationToken cancellationToken)
     {
@@ -381,6 +395,13 @@ public class QuotationsController : ControllerBase
     /// 更改既有預約日期，維持狀態為 190。
     /// </summary>
     [HttpPost("reserve/update")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationNo": "Q25100001",
+          "reservationDate": "2024-11-25T14:30:00"
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationStatusChangeResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<QuotationStatusChangeResponse>> UpdateReservationDateAsync([FromBody] QuotationReservationRequest request, CancellationToken cancellationToken)
     {
@@ -416,6 +437,14 @@ public class QuotationsController : ControllerBase
     /// 取消既有預約，狀態改為 195 並清除預約日期。
     /// </summary>
     [HttpPost("reserve/cancel")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationNo": "Q25100001",
+          "reason": "客戶無法到場",
+          "clearReservation": true
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationStatusChangeResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<QuotationStatusChangeResponse>> CancelReservationAsync([FromBody] QuotationCancelRequest request, CancellationToken cancellationToken)
     {
@@ -451,6 +480,12 @@ public class QuotationsController : ControllerBase
     /// 將估價單狀態回朔至上一個有效狀態。
     /// </summary>
     [HttpPost("reserve/revert")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationNo": "Q25100001"
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationStatusChangeResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<QuotationStatusChangeResponse>> RevertReservationStatusAsync([FromBody] QuotationRevertStatusRequest request, CancellationToken cancellationToken)
     {
@@ -486,6 +521,12 @@ public class QuotationsController : ControllerBase
     /// 將估價單轉為維修單，回傳新工單編號。
     /// </summary>
     [HttpPost("maintenance")]
+    [SwaggerMockRequestExample(
+        """
+        {
+          "quotationNo": "Q25100001"
+        }
+        """)]
     [ProducesResponseType(typeof(QuotationMaintenanceConversionResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<QuotationMaintenanceConversionResponse>> ConvertToMaintenanceAsync([FromBody] QuotationMaintenanceRequest request, CancellationToken cancellationToken)
     {

--- a/src/DentstageToolApp.Api/Quotations/QuotationActionRequestBase.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationActionRequestBase.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 估價單操作共用請求基底，提供估價單識別資訊欄位。
+/// </summary>
+public class QuotationActionRequestBase
+{
+    /// <summary>
+    /// 估價單唯一識別碼，可與估價單編號擇一提供。
+    /// </summary>
+    public string? QuotationUid { get; set; }
+
+    /// <summary>
+    /// 估價單編號，若同時提供將優先以編號查詢。
+    /// </summary>
+    public string? QuotationNo { get; set; }
+
+    /// <summary>
+    /// 驗證至少需提供一種識別方式，避免後端無法定位估價單。
+    /// </summary>
+    public void EnsureHasIdentity()
+    {
+        if (string.IsNullOrWhiteSpace(QuotationUid) && string.IsNullOrWhiteSpace(QuotationNo))
+        {
+            throw new ValidationException("請提供估價單編號或識別碼。");
+        }
+    }
+}

--- a/src/DentstageToolApp.Api/Quotations/QuotationActionRequestBase.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationActionRequestBase.cs
@@ -3,28 +3,26 @@ using System.ComponentModel.DataAnnotations;
 namespace DentstageToolApp.Api.Quotations;
 
 /// <summary>
-/// 估價單操作共用請求基底，提供估價單識別資訊欄位。
+/// 估價單操作共用請求基底，提供估價單編號欄位。
 /// </summary>
 public class QuotationActionRequestBase
 {
     /// <summary>
-    /// 估價單唯一識別碼，可與估價單編號擇一提供。
+    /// 估價單編號，後端以此為唯一識別依據。
     /// </summary>
-    public string? QuotationUid { get; set; }
-
-    /// <summary>
-    /// 估價單編號，若同時提供將優先以編號查詢。
-    /// </summary>
+    [Required(ErrorMessage = "請提供估價單編號。")]
     public string? QuotationNo { get; set; }
 
     /// <summary>
-    /// 驗證至少需提供一種識別方式，避免後端無法定位估價單。
+    /// 驗證估價單編號是否存在，並回傳整理後的編號字串。
     /// </summary>
-    public void EnsureHasIdentity()
+    public string EnsureAndGetQuotationNo()
     {
-        if (string.IsNullOrWhiteSpace(QuotationUid) && string.IsNullOrWhiteSpace(QuotationNo))
+        if (string.IsNullOrWhiteSpace(QuotationNo))
         {
-            throw new ValidationException("請提供估價單編號或識別碼。");
+            throw new ValidationException("請提供估價單編號。");
         }
+
+        return QuotationNo.Trim();
     }
 }

--- a/src/DentstageToolApp.Api/Quotations/QuotationCancelRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationCancelRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 取消估價單或預約的請求內容，提供取消原因。
+/// </summary>
+public class QuotationCancelRequest : QuotationActionRequestBase
+{
+    /// <summary>
+    /// 取消原因，若未填寫將於服務層套用預設說明。
+    /// </summary>
+    [MaxLength(255, ErrorMessage = "取消原因長度不可超過 255 個字元")]
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// 取消後是否需清除預約日期，預設僅取消估價單不移除預約資訊。
+    /// </summary>
+    public bool ClearReservation { get; set; }
+}

--- a/src/DentstageToolApp.Api/Quotations/QuotationListQuery.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationListQuery.cs
@@ -14,7 +14,7 @@ public class QuotationListQuery
     public string? FixType { get; set; }
 
     /// <summary>
-    /// 指定估價單狀態碼，對應資料表欄位 Status。 ALL->(null) 110估價中(編輯中) 180估價完成 190已預約 191預約取消(估價轉入) 195轉維修(待維修 )
+    /// 指定估價單狀態碼，對應資料表欄位 Status。 ALL->(null) 110估價中(編輯中) 180估價完成 190已預約 191轉維修(待維修) 195估價或預約取消。
     /// </summary>
     public string? Status { get; set; }
 

--- a/src/DentstageToolApp.Api/Quotations/QuotationMaintenanceConversionResponse.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationMaintenanceConversionResponse.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 估價單轉維修後回傳的資訊，包含新建工單資料。
+/// </summary>
+public class QuotationMaintenanceConversionResponse : QuotationStatusChangeResponse
+{
+    /// <summary>
+    /// 新建維修單的唯一識別碼。
+    /// </summary>
+    public string OrderUid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 新建維修單編號，供前端顯示與跳轉使用。
+    /// </summary>
+    public string OrderNo { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 維修單建立時間。
+    /// </summary>
+    public DateTime OrderCreatedAt { get; set; }
+}

--- a/src/DentstageToolApp.Api/Quotations/QuotationMaintenanceRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationMaintenanceRequest.cs
@@ -1,0 +1,8 @@
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 估價單轉維修的請求內容，使用估價單識別資訊即可。
+/// </summary>
+public class QuotationMaintenanceRequest : QuotationActionRequestBase
+{
+}

--- a/src/DentstageToolApp.Api/Quotations/QuotationMaintenanceRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationMaintenanceRequest.cs
@@ -1,7 +1,7 @@
 namespace DentstageToolApp.Api.Quotations;
 
 /// <summary>
-/// 估價單轉維修的請求內容，使用估價單識別資訊即可。
+/// 估價單轉維修的請求內容，僅需提供估價單編號。
 /// </summary>
 public class QuotationMaintenanceRequest : QuotationActionRequestBase
 {

--- a/src/DentstageToolApp.Api/Quotations/QuotationReservationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationReservationRequest.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 轉預約或設定預約日期的請求內容。
+/// </summary>
+public class QuotationReservationRequest : QuotationActionRequestBase
+{
+    /// <summary>
+    /// 指定的預約日期，服務層會轉換為 DateOnly 儲存。
+    /// </summary>
+    [Required(ErrorMessage = "請提供預約日期")]
+    public DateTime? ReservationDate { get; set; }
+}

--- a/src/DentstageToolApp.Api/Quotations/QuotationRevertStatusRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationRevertStatusRequest.cs
@@ -1,0 +1,8 @@
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 預約誤按回溯的請求內容，僅需估價單識別資訊。
+/// </summary>
+public class QuotationRevertStatusRequest : QuotationActionRequestBase
+{
+}

--- a/src/DentstageToolApp.Api/Quotations/QuotationRevertStatusRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationRevertStatusRequest.cs
@@ -1,7 +1,7 @@
 namespace DentstageToolApp.Api.Quotations;
 
 /// <summary>
-/// 預約誤按回溯的請求內容，僅需估價單識別資訊。
+/// 預約誤按回溯的請求內容，僅需估價單編號。
 /// </summary>
 public class QuotationRevertStatusRequest : QuotationActionRequestBase
 {

--- a/src/DentstageToolApp.Api/Quotations/QuotationStatusChangeResponse.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationStatusChangeResponse.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 估價單狀態異動後回傳的共用資訊。
+/// </summary>
+public class QuotationStatusChangeResponse
+{
+    /// <summary>
+    /// 估價單唯一識別碼，方便前端同步本地狀態。
+    /// </summary>
+    public string QuotationUid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 估價單編號。
+    /// </summary>
+    public string? QuotationNo { get; set; }
+
+    /// <summary>
+    /// 異動後的估價單狀態碼。
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 狀態異動時間，使用台北時間回傳。
+    /// </summary>
+    public DateTime StatusChangedAt { get; set; }
+
+    /// <summary>
+    /// 目前預約日期（若有），方便前端更新排程資訊。
+    /// </summary>
+    public DateTime? ReservationDate { get; set; }
+}

--- a/src/DentstageToolApp.Api/Quotations/UpdateQuotationRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/UpdateQuotationRequest.cs
@@ -6,17 +6,8 @@ namespace DentstageToolApp.Api.Quotations;
 /// <summary>
 /// 編輯估價單所需的欄位，聚焦車輛、客戶與各類別備註。
 /// </summary>
-public class UpdateQuotationRequest
+public class UpdateQuotationRequest : QuotationActionRequestBase
 {
-    /// <summary>
-    /// 估價單唯一識別碼，優先使用於更新。
-    /// </summary>
-    public string? QuotationUid { get; set; }
-
-    /// <summary>
-    /// 估價單編號，若未提供 UID 可改以編號更新。
-    /// </summary>
-    public string? QuotationNo { get; set; }
 
     /// <summary>
     /// 車輛資訊。

--- a/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
@@ -39,4 +39,34 @@ public interface IQuotationService
     /// <param name="operatorName">操作人員名稱。</param>
     /// <param name="cancellationToken">取消權杖。</param>
     Task UpdateQuotationAsync(UpdateQuotationRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 取消估價單或預約，將狀態調整為 195 並記錄操作資訊。
+    /// </summary>
+    Task<QuotationStatusChangeResponse> CancelQuotationAsync(QuotationCancelRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 將估價單狀態轉為預約，寫入預約日期並回傳異動資訊。
+    /// </summary>
+    Task<QuotationStatusChangeResponse> ConvertToReservationAsync(QuotationReservationRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 更新已預約估價單的預約日期，維持狀態為 190。
+    /// </summary>
+    Task<QuotationStatusChangeResponse> UpdateReservationDateAsync(QuotationReservationRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 取消既有預約，保留取消原因並清除預約日期。
+    /// </summary>
+    Task<QuotationStatusChangeResponse> CancelReservationAsync(QuotationCancelRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 將狀態回朔至上一個有效狀態，供預約取消後誤按回復使用。
+    /// </summary>
+    Task<QuotationStatusChangeResponse> RevertQuotationStatusAsync(QuotationRevertStatusRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 估價單轉維修，建立維修工單並回傳工單編號。
+    /// </summary>
+    Task<QuotationMaintenanceConversionResponse> ConvertToMaintenanceAsync(QuotationMaintenanceRequest request, string operatorName, CancellationToken cancellationToken);
 }

--- a/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
@@ -28,7 +28,7 @@ public interface IQuotationService
     /// <summary>
     /// 取得單一估價單的詳細資訊。
     /// </summary>
-    /// <param name="request">查詢條件，支援以 UID 或編號取得。</param>
+    /// <param name="request">查詢條件，僅需提供估價單編號即可。</param>
     /// <param name="cancellationToken">取消權杖。</param>
     Task<QuotationDetailResponse> GetQuotationAsync(GetQuotationRequest request, CancellationToken cancellationToken);
 


### PR DESCRIPTION
## 摘要
- 新增取消估價、轉預約、調整預約、取消預約、狀態回溯與轉維修等 API 端點
- 擴充估價單服務，整合狀態異動、維修單建檔與時間使用者記錄
- 補充估價單操作所需的請求與回應資料模型

## 測試
- 無，環境未提供 dotnet 指令

------
https://chatgpt.com/codex/tasks/task_e_68df7038f4c08324a82338c68062d41c