### PR TITLE
新增估價完成狀態更新 API 與服務流程

### DIFF
--- a/src/DentstageToolApp.Api/Quotations/QuotationEvaluateRequest.cs
+++ b/src/DentstageToolApp.Api/Quotations/QuotationEvaluateRequest.cs
@@ -1,0 +1,9 @@
+namespace DentstageToolApp.Api.Quotations;
+
+/// <summary>
+/// 估價完成請求，僅需帶入估價單編號即可觸發狀態更新。
+/// </summary>
+public class QuotationEvaluateRequest : QuotationActionRequestBase
+{
+    // 目前僅沿用父類別的 QuotationNo 欄位，保留類別結構方便未來擴充其他需求。
+}

--- a/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
+++ b/src/DentstageToolApp.Api/Services/Quotation/IQuotationService.cs
@@ -41,6 +41,14 @@ public interface IQuotationService
     Task UpdateQuotationAsync(UpdateQuotationRequest request, string operatorName, CancellationToken cancellationToken);
 
     /// <summary>
+    /// 將估價單標記為估價完成，狀態更新為 180。
+    /// </summary>
+    /// <param name="request">估價完成請求，需帶入估價單編號。</param>
+    /// <param name="operatorName">操作人員名稱。</param>
+    /// <param name="cancellationToken">取消權杖。</param>
+    Task<QuotationStatusChangeResponse> CompleteEvaluationAsync(QuotationEvaluateRequest request, string operatorName, CancellationToken cancellationToken);
+
+    /// <summary>
     /// 取消估價單或預約，將狀態調整為 195 並記錄操作資訊。
     /// </summary>
     Task<QuotationStatusChangeResponse> CancelQuotationAsync(QuotationCancelRequest request, string operatorName, CancellationToken cancellationToken);


### PR DESCRIPTION
## 摘要
- 新增 POST /api/quotations/evaluate API，提供估價完成狀態更新並補上 Swagger 範例
- 擴充估價服務介面與實作，僅允許 110/180 狀態進行估價完成並記錄操作資訊
- 補上 QuotationEvaluateRequest 模型以利請求格式管理

## 測試
- dotnet build（環境缺少 dotnet CLI 無法執行）

------
https://chatgpt.com/codex/tasks/task_e_68df83f37b4883249a403406afa11854