### PR TITLE
調整估價單狀態回朔 API 邏輯

### DIFF
--- a/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
+++ b/src/DentstageToolApp.Api/Controllers/QuotationsController.cs
@@ -521,7 +521,7 @@ public class QuotationsController : ControllerBase
     /// <summary>
     /// 將估價單狀態回朔至上一個有效狀態。
     /// </summary>
-    [HttpPost("reserve/revert")]
+    [HttpPost("revert")]
     [SwaggerMockRequestExample(
         """
         {


### PR DESCRIPTION
## 摘要
- 更新估價單狀態回朔端點為 /api/quotations/revert 以符合最新路由需求
- 重構狀態回朔歷程判斷，依照狀態流程回推並支援最小回朔至 110

## 測試
- 未執行自動化測試（依需求可直接提交）

------
https://chatgpt.com/codex/tasks/task_e_68e5ef837b24832483ad9356ca06852f