### PR TITLE
修正：API 流程測試工具整合快速帶入清單

### DIFF
--- a/src/DentstageToolApp.Api/docs/api-flow-tester.html
+++ b/src/DentstageToolApp.Api/docs/api-flow-tester.html
@@ -1089,17 +1089,21 @@
           }).format(timestamp);
         };
 
+        // ---------- API 快速帶入靜態範本 ----------
+        // 依據 API 文件整理常用端點，協助在無 Swagger 定義時依舊能快速組裝請求。
         const staticOperationGroups = [
           {
-            name: '常用｜驗證流程',
+            name: '常用｜授權與維運',
             operations: [
               {
                 name: '登入取得權杖',
                 method: 'POST',
                 path: '/auth/login',
-                template: { deviceKey: 'CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C' },
+                template: {
+                  deviceKey: 'CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C'
+                },
                 requiresAuth: false,
-                description: '使用裝置機碼取得 Access Token 與 Refresh Token。'
+                description: '以裝置機碼取得 Access/Refresh Token。'
               },
               {
                 name: '刷新 Access Token',
@@ -1110,20 +1114,70 @@
                   deviceKey: 'CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C'
                 },
                 requiresAuth: false,
-                description: '以 Refresh Token 換取新的 Access Token。'
+                description: '使用 Refresh Token 重新取得 Access Token。'
               },
               {
                 name: '取得登入者資訊',
                 method: 'GET',
                 path: '/auth/info',
                 requiresAuth: true,
-                description: '檢視目前登入者的顯示名稱與角色。'
+                description: '查詢目前登入者的顯示名稱與角色。'
+              },
+              {
+                name: '建立後台帳號與裝置',
+                method: 'POST',
+                path: '/admin/accounts',
+                template: {
+                  displayName: '陳大明',
+                  role: 'StoreManager',
+                  deviceKey: 'CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C',
+                  deviceName: '高雄總店平板',
+                  operatorName: 'SystemAdmin'
+                },
+                requiresAuth: true,
+                description: '建立管理者帳號並綁定登入裝置。'
+              },
+              {
+                name: '健康檢查',
+                method: 'GET',
+                path: '/healthcheck',
+                requiresAuth: false,
+                description: '確認服務是否運作中（免權杖）。'
               }
             ]
           },
           {
-            name: '車牌流程',
+            name: '基礎資料｜品牌與技師',
             operations: [
+              {
+                name: '品牌與型號清單',
+                method: 'GET',
+                path: '/brands-models',
+                requiresAuth: true,
+                description: '取得品牌與車型樹狀資料供下拉選單使用。'
+              },
+              {
+                name: '技師名單',
+                method: 'GET',
+                path: '/technicians',
+                requiresAuth: true,
+                description: '依登入者所屬門市列出技師清單。'
+              }
+            ]
+          },
+          {
+            name: '車牌模組',
+            operations: [
+              {
+                name: '車牌影像辨識',
+                method: 'POST',
+                path: '/car-plates/recognitions',
+                template: {
+                  imageBase64: 'data:image/jpeg;base64,<貼上影像編碼>'
+                },
+                requiresAuth: true,
+                description: '支援檔案或 Base64，本範例示範以 Base64 字串送出辨識。'
+              },
               {
                 name: '車牌維修紀錄查詢',
                 method: 'POST',
@@ -1132,12 +1186,12 @@
                   carPlateNumber: 'AAA-1234'
                 },
                 requiresAuth: true,
-                description: '依車牌取得維修紀錄摘要。'
+                description: '依車牌號碼取得歷史估價與維修紀錄。'
               }
             ]
           },
           {
-            name: '客戶與車輛',
+            name: '客戶模組',
             operations: [
               {
                 name: '新增客戶',
@@ -1156,7 +1210,7 @@
                   remark: '首次到店，請協助安排體驗'
                 },
                 requiresAuth: true,
-                description: '建立客戶基本資料。'
+                description: '建立客戶主檔，欄位與後端驗證相符。'
               },
               {
                 name: '編輯客戶',
@@ -1176,7 +1230,7 @@
                   remark: '首次到店，請協助安排體驗'
                 },
                 requiresAuth: true,
-                description: '更新既有客戶資料。'
+                description: '更新既有客戶資料，需帶入 customerUid。'
               },
               {
                 name: '電話搜尋客戶',
@@ -1186,8 +1240,13 @@
                   phone: '0988123456'
                 },
                 requiresAuth: true,
-                description: '依電話關鍵字查詢客戶與維修紀錄統計。'
-              },
+                description: '依電話查詢客戶資料與維修次數統計。'
+              }
+            ]
+          },
+          {
+            name: '車輛模組',
+            operations: [
               {
                 name: '新增車輛',
                 method: 'POST',
@@ -1196,11 +1255,11 @@
                   carPlateNumber: 'AAA-1234',
                   brandUid: 'B_C7CAB67F-9F5A-11F0-A812-000C2990DEAF',
                   modelUid: 'M_E706D04B-9F5A-11F0-A812-000C2990DEAF',
-                  color: '白',
-                  remark: '測試建立車輛資料'
+                  color: '白色',
+                  remark: '建立車輛測試資料'
                 },
                 requiresAuth: true,
-                description: '建立車輛資料並綁定車牌。'
+                description: '新增車輛主檔，需搭配品牌與型號 UID。'
               },
               {
                 name: '編輯車輛',
@@ -1211,19 +1270,26 @@
                   carPlateNumber: 'AAA-5678',
                   brandUid: 'B_C7CAB67F-9F5A-11F0-A812-000C2990DEAF',
                   modelUid: 'M_E706D04B-9F5A-11F0-A812-000C2990DEAF',
-                  color: '黑',
-                  remark: '客戶更換為黑色烤漆'
+                  color: '黑色',
+                  remark: '客戶更換車色為黑'
                 },
                 requiresAuth: true,
-                description: '更新既有車輛資料。'
+                description: '更新既有車輛資料，需帶入 carUid。'
               }
             ]
           },
           {
-            name: '常用｜估價與維修',
+            name: '估價單模組',
             operations: [
               {
-                name: '查詢估價單列表 (POST)',
+                name: '估價單列表 (GET)',
+                method: 'GET',
+                path: '/quotations?status=110&page=1&pageSize=20',
+                requiresAuth: true,
+                description: '以查詢參數取得估價單列表，預設查詢估價中資料。'
+              },
+              {
+                name: '估價單列表 (POST)',
                 method: 'POST',
                 path: '/quotations',
                 template: {
@@ -1237,7 +1303,7 @@
                   pageSize: 20
                 },
                 requiresAuth: true,
-                description: '依條件取得估價單列表。'
+                description: '透過 Body 傳遞查詢條件，欄位對應 QuotationListQuery。'
               },
               {
                 name: '新增估價單',
@@ -1258,47 +1324,23 @@
                   },
                   damages: [
                     {
-                      photos: 'Ph_759F19C7-5D62-4DB2-8021-2371C3136F7B',
                       position: '保桿',
                       dentStatus: '大面積',
                       description: '需板金搭配烤漆',
                       estimatedAmount: 4500
                     }
                   ],
-                  carBodyConfirmation: {
-                    signaturePhotoUid: 'Ph_D4FB9159-CD9E-473A-A3D9-0A8FDD0B76F8',
-                    damageMarkers: [
-                      {
-                        x: 0.42,
-                        y: 0.63,
-                        hasDent: true,
-                        hasScratch: false,
-                        hasPaintPeel: false,
-                        remark: '主要凹痕'
-                      }
-                    ]
-                  },
                   maintenance: {
                     fixTypeUid: 'F_9C2EDFDA-9F5A-11F0-A812-000C2990DEAF',
                     reserveCar: true,
-                    applyCoating: false,
-                    applyWrapping: false,
-                    hasRepainted: false,
-                    needToolEvaluation: true,
-                    otherFee: 800,
-                    roundingDiscount: 200,
-                    percentageDiscount: 10,
-                    discountReason: '回饋老客戶',
                     estimatedRepairDays: 1,
                     estimatedRepairHours: 6,
                     estimatedRestorationPercentage: 90,
-                    suggestedPaintReason: null,
-                    unrepairableReason: null,
                     remark: '請於修復後通知客戶取車'
                   }
                 },
                 requiresAuth: true,
-                description: '建立估價單，需先準備車輛、客戶與圖片資料。'
+                description: '建立估價單，需先準備車輛、客戶與維修設定。'
               },
               {
                 name: '估價單詳情',
@@ -1308,96 +1350,183 @@
                   quotationNo: 'Q25100001'
                 },
                 requiresAuth: true,
-                description: '依估價單編號取得詳情。'
+                description: '依估價單編號取得完整內容。'
+              },
+              {
+                name: '編輯估價單',
+                method: 'POST',
+                path: '/quotations/edit',
+                template: {
+                  quotationNo: 'Q25100001',
+                  remark: '更新估價備註',
+                  damages: [
+                    {
+                      position: '車門',
+                      dentStatus: '輕微',
+                      description: '補充描述',
+                      estimatedAmount: 1800
+                    }
+                  ],
+                  maintenance: {
+                    fixTypeUid: 'F_9C2EDFDA-9F5A-11F0-A812-000C2990DEAF',
+                    reserveCar: false,
+                    estimatedRepairDays: 1,
+                    estimatedRepairHours: 4
+                  }
+                },
+                requiresAuth: true,
+                description: '更新估價單內容，需帶入 quotationNo。'
+              },
+              {
+                name: '估價完成',
+                method: 'POST',
+                path: '/quotations/evaluate',
+                template: {
+                  quotationNo: 'Q25100001'
+                },
+                requiresAuth: true,
+                description: '將狀態更新為估價完成 (180)。'
+              },
+              {
+                name: '取消估價/預約',
+                method: 'POST',
+                path: '/quotations/cancel',
+                template: {
+                  quotationNo: 'Q25100001',
+                  reason: '客戶取消到店',
+                  clearReservation: true
+                },
+                requiresAuth: true,
+                description: '取消估價或預約，可選擇是否清除預約日期。'
+              },
+              {
+                name: '轉預約或設定日期',
+                method: 'POST',
+                path: '/quotations/reserve',
+                template: {
+                  quotationNo: 'Q25100001',
+                  reservationDate: '2024-10-20T10:00:00'
+                },
+                requiresAuth: true,
+                description: '設定預約日期，將狀態轉為預約中。'
+              },
+              {
+                name: '更新預約日期',
+                method: 'POST',
+                path: '/quotations/reserve/update',
+                template: {
+                  quotationNo: 'Q25100001',
+                  reservationDate: '2024-10-28T09:30:00'
+                },
+                requiresAuth: true,
+                description: '異動既有預約日期。'
+              },
+              {
+                name: '取消預約',
+                method: 'POST',
+                path: '/quotations/reserve/cancel',
+                template: {
+                  quotationNo: 'Q25100001',
+                  reason: '客戶延期',
+                  clearReservation: true
+                },
+                requiresAuth: true,
+                description: '取消預約並視需求清除預約日期。'
+              },
+              {
+                name: '估價狀態回溯',
+                method: 'POST',
+                path: '/quotations/revert',
+                template: {
+                  quotationNo: 'Q25100001'
+                },
+                requiresAuth: true,
+                description: '將估價單狀態回復上一階段。'
+              },
+              {
+                name: '估價轉維修',
+                method: 'POST',
+                path: '/quotations/maintenance',
+                template: {
+                  quotationNo: 'Q25100001'
+                },
+                requiresAuth: true,
+                description: '將估價單轉為維修單並產生維修編號。'
+              }
+            ]
+          },
+          {
+            name: '維修單模組',
+            operations: [
+              {
+                name: '維修單列表 (GET)',
+                method: 'GET',
+                path: '/maintenance-orders?status=210&page=1&pageSize=20',
+                requiresAuth: true,
+                description: '以查詢參數取得維修單列表，預設查詢待確認資料。'
               },
               {
                 name: '維修單列表 (POST)',
                 method: 'POST',
                 path: '/maintenance-orders',
                 template: {
+                  status: '220',
+                  startDate: '2024-03-01T00:00:00',
+                  endDate: '2024-03-31T23:59:59',
                   page: 1,
-                  pageSize: 20,
-                  status: '200'
+                  pageSize: 20
                 },
                 requiresAuth: true,
-                description: '以 POST 方式取得維修單列表。'
+                description: '透過 Body 查詢維修單，欄位對應 MaintenanceOrderListQuery。'
               },
               {
                 name: '維修單詳情',
                 method: 'POST',
                 path: '/maintenance-orders/detail',
                 template: {
-                  maintenanceOrderUid: 'MO_1234567890'
+                  orderNo: 'M25100001'
                 },
                 requiresAuth: true,
-                description: '查詢單一維修單的詳細資料。'
+                description: '依維修單編號取得詳細資料。'
               },
               {
                 name: '維修單回溯',
                 method: 'POST',
                 path: '/maintenance-orders/revert',
                 template: {
-                  maintenanceOrderUid: 'MO_1234567890',
-                  revertReason: '測試回溯原因'
+                  orderNo: 'M25100001'
                 },
                 requiresAuth: true,
-                description: '將維修單狀態回復上一個節點。'
+                description: '誤按狀態時回復上一階段。'
               },
               {
                 name: '確認維修開始',
                 method: 'POST',
                 path: '/maintenance-orders/confirm',
                 template: {
-                  maintenanceOrderUid: 'MO_1234567890',
-                  confirmRemark: '現場確認開始維修'
+                  orderNo: 'M25100001'
                 },
                 requiresAuth: true,
-                description: '更新維修單狀態為維修中。'
+                description: '更新狀態為維修中。'
               }
             ]
           },
           {
-            name: '常用｜資源查詢',
+            name: '圖片模組',
             operations: [
               {
-                name: '健康檢查',
-                method: 'GET',
-                path: '/healthcheck',
-                requiresAuth: false,
-                description: '確認服務是否運作中。'
-              },
-              {
-                name: '品牌與型號清單',
-                method: 'GET',
-                path: '/brands-models',
-                requiresAuth: true,
-                description: '取得車輛品牌與型號下拉選單資料。'
-              },
-              {
-                name: '技師名單',
-                method: 'GET',
-                path: '/technicians',
-                requiresAuth: true,
-                description: '取得登入者所屬門市的技師列表。'
-              }
-            ]
-          },
-          {
-            name: '常用｜系統維運',
-            operations: [
-              {
-                name: '建立後台帳號與裝置',
+                name: '上傳維修/估價照片',
                 method: 'POST',
-                path: '/admin/accounts',
-                template: {
-                  displayName: '陳大明',
-                  role: 'StoreManager',
-                  deviceKey: 'CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C',
-                  deviceName: '高雄總店平板',
-                  operatorName: 'SystemAdmin'
-                },
+                path: '/photos',
                 requiresAuth: true,
-                description: '建立管理者帳號並綁定裝置。'
+                description: '需使用下方「圖片上傳測試」卡片送出 multipart/form-data。'
+              },
+              {
+                name: '下載圖片',
+                method: 'GET',
+                path: '/photos/{photoUid}',
+                requiresAuth: true,
+                description: '以取得的 photoUid 下載原始影像。'
               }
             ]
           }

--- a/src/DentstageToolApp.Api/docs/api/api-quick-reference.md
+++ b/src/DentstageToolApp.Api/docs/api/api-quick-reference.md
@@ -1,0 +1,247 @@
+# API 操作快速帶入指南
+
+本文件整理目前後端所有公開 API 端點，提供以文件撰寫方式快速建立 Postman、Hoppscotch、VSCode REST Client 等工具的請求範本，無須依賴 Swagger 匯入。建議於專案啟動後以實際 Base URL（例如 `https://{domain}/` 或 `https://localhost:5001/`）搭配下述路徑呼叫。
+
+> **授權提醒**：除 `api/healthcheck` 外，其餘端點皆預設啟用 JWT 驗證。請於請求標頭帶入 `Authorization: Bearer {token}`。
+
+---
+
+## Auth 模組（`api/auth`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| POST | `/api/auth/login` | 以裝置機碼登入取得 Access/Refresh Token。 | Body 採 JSON，對應 `LoginRequest`。 |
+| POST | `/api/auth/token/refresh` | 使用 Refresh Token 換發新的權杖。 | Body 採 JSON，對應 `RefreshTokenRequest`。 |
+| GET | `/api/auth/info` | 查詢目前登入者資訊。 | 需攜帶權杖。 |
+
+**登入請求範例**
+```http
+POST /api/auth/login HTTP/1.1
+Content-Type: application/json
+
+{
+  "deviceKey": "CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C"
+}
+```
+- `deviceKey`：裝置機碼，長度上限 150。 【F:src/DentstageToolApp.Api/Auth/LoginRequest.cs†L5-L15】
+
+**Refresh Token 請求範例**
+```http
+POST /api/auth/token/refresh HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {舊的AccessToken}
+
+{
+  "refreshToken": "{舊的RefreshToken}",
+  "deviceKey": "CFC29A95-885C-CF45-A91C-F0DD3F1DDD7C"
+}
+```
+- `refreshToken`：舊 Refresh Token。 【F:src/DentstageToolApp.Api/Auth/RefreshTokenRequest.cs†L5-L21】
+- `deviceKey`：再次驗證裝置綁定。
+
+---
+
+## 管理者帳號模組（`api/admin/accounts`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| POST | `/api/admin/accounts` | 建立使用者帳號與裝置機碼。 | Body 採 JSON，對應 `CreateUserDeviceRequest`。 |
+
+**請求欄位重點**
+- `displayName`：必填顯示名稱。 【F:src/DentstageToolApp.Api/Admin/CreateUserDeviceRequest.cs†L5-L15】
+- `role`：選填角色識別。
+- `deviceKey`：必填裝置機碼。 【F:src/DentstageToolApp.Api/Admin/CreateUserDeviceRequest.cs†L23-L28】
+- `deviceName`、`operatorName`：裝置說明與建立者備註。 【F:src/DentstageToolApp.Api/Admin/CreateUserDeviceRequest.cs†L30-L40】
+
+---
+
+## 車輛模組（`api/cars`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| POST | `/api/cars` | 新增車輛。 | Body 採 JSON，對應 `CreateCarRequest`。 |
+| POST | `/api/cars/edit` | 編輯車輛。 | Body 採 JSON，對應 `EditCarRequest`。 |
+
+**新增車輛主要欄位**
+- `carPlateNumber`：必填車牌號碼。 【F:src/DentstageToolApp.Api/Cars/CreateCarRequest.cs†L10-L15】
+- `brandUid`、`modelUid`：對應品牌/車型 UID。 【F:src/DentstageToolApp.Api/Cars/CreateCarRequest.cs†L17-L27】
+- `color`、`remark`：車色與備註。 【F:src/DentstageToolApp.Api/Cars/CreateCarRequest.cs†L29-L39】
+
+**編輯車輛需加帶欄位**
+- `carUid`：欲更新的車輛識別碼。 【F:src/DentstageToolApp.Api/Cars/EditCarRequest.cs†L10-L15】
+- 其餘欄位與新增格式相同，可選擇保留或清空。 【F:src/DentstageToolApp.Api/Cars/EditCarRequest.cs†L17-L46】
+
+---
+
+## 客戶模組（`api/customers`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| POST | `/api/customers` | 新增客戶資料。 | Body 採 JSON，對應 `CreateCustomerRequest`。 |
+| POST | `/api/customers/edit` | 編輯客戶資料。 | Body 採 JSON，對應 `EditCustomerRequest`。 |
+| POST | `/api/customers/phone-search` | 依電話搜尋客戶與維修統計。 | Body 採 JSON，對應 `CustomerPhoneSearchRequest`。 |
+
+**新增／編輯欄位重點**
+- `customerName`：必填客戶名稱。 【F:src/DentstageToolApp.Api/Customers/CreateCustomerRequest.cs†L10-L15】【F:src/DentstageToolApp.Api/Customers/EditCustomerRequest.cs†L17-L22】
+- `phone`、`email`：聯絡資訊（會自動整理格式）。 【F:src/DentstageToolApp.Api/Customers/CreateCustomerRequest.cs†L17-L52】
+- `category`、`gender`、`county`、`township`、`source`、`reason`、`remark`：分類與補充說明。 【F:src/DentstageToolApp.Api/Customers/CreateCustomerRequest.cs†L23-L70】
+- 編輯時需額外帶入 `customerUid`。 【F:src/DentstageToolApp.Api/Customers/EditCustomerRequest.cs†L10-L15】
+
+**電話搜尋請求**
+```http
+POST /api/customers/phone-search HTTP/1.1
+Content-Type: application/json
+
+{
+  "phone": "0988123456"
+}
+```
+- `phone`：必填且長度上限 50。 【F:src/DentstageToolApp.Api/Customers/CustomerPhoneSearchRequest.cs†L5-L15】
+
+---
+
+## 估價單模組（`api/quotations`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| GET | `/api/quotations` | 以查詢參數取得估價單列表。 | Query 對應 `QuotationListQuery`。 |
+| POST | `/api/quotations` | 以 Body 送出查詢條件取得列表。 | JSON 對應 `QuotationListQuery`。 |
+| POST | `/api/quotations/create` | 建立估價單。 | JSON 對應 `CreateQuotationRequest`。 |
+| POST | `/api/quotations/detail` | 取得估價單詳細。 | JSON 對應 `GetQuotationRequest`。 |
+| POST | `/api/quotations/edit` | 編輯估價單。 | JSON 對應 `UpdateQuotationRequest`。 |
+| POST | `/api/quotations/evaluate` | 將狀態更新為估價完成。 | JSON 對應 `QuotationEvaluateRequest`。 |
+| POST | `/api/quotations/cancel` | 取消估價或預約。 | JSON 對應 `QuotationCancelRequest`。 |
+| POST | `/api/quotations/reserve` | 轉為預約並設定日期。 | JSON 對應 `QuotationReservationRequest`。 |
+| POST | `/api/quotations/reserve/update` | 更新既有預約日期。 | JSON 同 `QuotationReservationRequest`。 |
+| POST | `/api/quotations/reserve/cancel` | 取消預約並清除日期。 | JSON 同 `QuotationCancelRequest`。 |
+| POST | `/api/quotations/revert` | 將估價單狀態回溯。 | JSON 對應 `QuotationRevertStatusRequest`。 |
+| POST | `/api/quotations/maintenance` | 估價單轉維修並產生維修單。 | JSON 對應 `QuotationMaintenanceRequest`。 |
+
+**列表查詢常用欄位**
+- `fixType`：維修類型代碼。 【F:src/DentstageToolApp.Api/Quotations/QuotationListQuery.cs†L11-L18】
+- `status`：估價單狀態碼（110/180/190/191/195）。 【F:src/DentstageToolApp.Api/Quotations/QuotationListQuery.cs†L16-L19】
+- `startDate`、`endDate`、`customerKeyword`、`carPlateKeyword`、`page`、`pageSize`。 【F:src/DentstageToolApp.Api/Quotations/QuotationListQuery.cs†L21-L51】
+
+**建立／編輯估價單主要結構**
+```json
+{
+  "store": {
+    "technicianUid": "技師UID",
+    "source": "來源",
+    "reservationDate": "2024-10-15T10:00:00",
+    "repairDate": "2024-10-25T09:00:00"
+  },
+  "car": {
+    "carUid": "車輛UID"
+  },
+  "customer": {
+    "customerUid": "客戶UID"
+  },
+  "damages": [ /* 估價傷痕清單 */ ],
+  "carBodyConfirmation": { /* 車體確認單資訊 */ },
+  "maintenance": { /* 維修設定 */ }
+}
+```
+- `store`：需帶技師 UID、來源與可選的預約／維修日期。 【F:src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs†L13-L52】
+- `maintenance`：含維修類型、留車、折扣、估工等設定。 【F:src/DentstageToolApp.Api/Quotations/CreateQuotationRequest.cs†L34-L120】
+- `damages`：可同時帶多筆傷痕項目，格式沿用 `QuotationDamageItem`（詳見程式碼）。
+- 編輯時需額外帶入 `quotationNo`，其餘欄位結構相同。 【F:src/DentstageToolApp.Api/Quotations/UpdateQuotationRequest.cs†L9-L46】
+
+**狀態操作共通欄位**
+- `quotationNo`：所有狀態操作必帶欄位。 【F:src/DentstageToolApp.Api/Quotations/QuotationActionRequestBase.cs†L5-L27】
+- `reservationDate`：轉預約／更新預約時必填。 【F:src/DentstageToolApp.Api/Quotations/QuotationReservationRequest.cs†L9-L15】
+- `reason`、`clearReservation`：取消預約時可提供原因與是否清除日期。 【F:src/DentstageToolApp.Api/Quotations/QuotationCancelRequest.cs†L5-L19】
+
+---
+
+## 維修單模組（`api/maintenance-orders`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| GET | `/api/maintenance-orders` | 以查詢參數取得維修單列表。 | Query 對應 `MaintenanceOrderListQuery`。 |
+| POST | `/api/maintenance-orders` | 透過 Body 查詢維修單列表。 | JSON 同 `MaintenanceOrderListQuery`。 |
+| POST | `/api/maintenance-orders/detail` | 取得維修單詳細。 | JSON 對應 `MaintenanceOrderDetailRequest`。 |
+| POST | `/api/maintenance-orders/revert` | 維修單狀態回溯。 | JSON 對應 `MaintenanceOrderRevertRequest`。 |
+| POST | `/api/maintenance-orders/confirm` | 確認維修開始。 | JSON 對應 `MaintenanceOrderConfirmRequest`。 |
+
+**查詢欄位重點**
+- `fixType`、`status`、`startDate`、`endDate`：對應篩選條件。 【F:src/DentstageToolApp.Api/MaintenanceOrders/MaintenanceOrderListQuery.cs†L11-L29】
+- `page`、`pageSize`：分頁設定。 【F:src/DentstageToolApp.Api/MaintenanceOrders/MaintenanceOrderListQuery.cs†L31-L41】
+
+**單筆操作欄位**
+- `orderNo`：維修單編號，為詳細／回溯／確認的必填欄位。 【F:src/DentstageToolApp.Api/MaintenanceOrders/MaintenanceOrderDetailRequest.cs†L5-L15】【F:src/DentstageToolApp.Api/MaintenanceOrders/MaintenanceOrderRevertRequest.cs†L5-L14】【F:src/DentstageToolApp.Api/MaintenanceOrders/MaintenanceOrderConfirmRequest.cs†L5-L14】
+
+---
+
+## 圖片模組（`api/photos`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| POST | `/api/photos` | 上傳估價／維修照片並取得 `photoUid`。 | `multipart/form-data`，檔案欄位為 `file`。 |
+| GET | `/api/photos/{photoUid}` | 下載指定圖片。 | 需帶有效的 `photoUid`。 |
+
+**上傳注意事項**
+- 表單欄位名稱為 `file`，大小限制 50 MB。 【F:src/DentstageToolApp.Api/Controllers/PhotosController.cs†L37-L69】
+- 成功時回傳 `photoUid` 與檔案資訊，可直接寫入估價單。 【F:src/DentstageToolApp.Api/Controllers/PhotosController.cs†L70-L101】
+
+---
+
+## 車牌模組（`api/car-plates`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| POST | `/api/car-plates/recognitions` | 上傳車牌影像進行辨識。 | `multipart/form-data`，支援檔案或 Base64 欄位。 |
+| POST | `/api/car-plates/search` | 依車牌號碼查詢歷史維修資料。 | JSON 對應 `CarPlateMaintenanceHistoryRequest`。 |
+
+**辨識請求欄位**
+- `image`：上傳檔案。 【F:src/DentstageToolApp.Api/CarPlates/CarPlateRecognitionRequest.cs†L10-L13】
+- `imageBase64`：若無檔案可帶 Base64 字串。 【F:src/DentstageToolApp.Api/CarPlates/CarPlateRecognitionRequest.cs†L15-L18】
+
+**維修紀錄查詢欄位**
+- `carPlateNumber`：欲查詢的車牌號碼。 【F:src/DentstageToolApp.Api/CarPlates/CarPlateMaintenanceHistoryRequest.cs†L3-L11】
+
+---
+
+## 品牌／型號模組（`api/brands-models`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| GET | `/api/brands-models` | 取得品牌與車型清單。 | 無需額外參數。 |
+
+此端點會回傳品牌與車型的樹狀資料，供前端建立下拉清單。 【F:src/DentstageToolApp.Api/Controllers/BrandModelsController.cs†L16-L64】
+
+---
+
+## 技師模組（`api/technicians`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| GET | `/api/technicians` | 依登入者所屬門市取得技師名單。 | 需帶權杖，後端會從 Claims 解析使用者 UID。 |
+
+查詢時後端會從 JWT 取出 `sub` 或 `displayName` 等欄位，並回傳對應技師資訊列表。 【F:src/DentstageToolApp.Api/Controllers/TechniciansController.cs†L17-L73】
+
+---
+
+## 健康檢查（`api/healthcheck`）
+
+| 方法 | 路徑 | 功能摘要 | 備註 |
+| --- | --- | --- | --- |
+| GET | `/api/healthcheck` | 回傳服務狀態與時間戳記。 | 無需授權，可做為監控用途。 |
+
+回應內容範例：
+```json
+{
+  "status": "healthy",
+  "message": "後端服務啟動成功",
+  "timestamp": "2024-01-01T00:00:00Z"
+}
+```
+【F:src/DentstageToolApp.Api/Controllers/HealthCheckController.cs†L7-L26】
+
+---
+
+## 使用建議
+1. 依需求建立環境變數管理 Base URL 與權杖，避免重複輸入。
+2. 測試檔案上傳時可使用 Postman 的 form-data 或 VSCode REST Client 的 `@` 語法指向本地檔案。
+3. 若需批次測試狀態流轉，建議按照「建立估價單 → 轉預約／轉維修 → 建立維修單 → 確認維修」順序執行，方便追蹤流程。
+4. 所有狀態變更皆需權杖內含 `displayName` 或 `sub`，請確認登入流程正常取得 Claims。


### PR DESCRIPTION
## 摘要
- 在 `api-flow-tester.html` 中補充靜態 API 操作群組，整理授權、客戶、車輛等常見端點
- 新增估價單、維修單、圖片與車牌模組的請求範本，無需載入 Swagger 也能快速帶入測試
- 補上中文註解說明靜態範本來源與用途，方便後續維護與擴充

## 測試
- 未執行（靜態頁面調整）

------
https://chatgpt.com/codex/tasks/task_e_68e5f184960c8324ab83e1ca31dafc9c